### PR TITLE
Add SSE2 backend for x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Library for drawing [lottie animations](https://en.wikipedia.org/wiki/Lottie_(file_format)), written in Rust.
 
 - Micro-optimized and [benchmarked](#benchmarks) across 17k+ animations from Telegram, against [rlottie](https://github.com/Samsung/rlottie) and [thorvg](https://github.com/thorvg/thorvg).
-- SIMD on ARM NEON, and WASM: [web demo](https://dkaraush.github.io/tlottie/examples/web/).
+- SIMD on ARM NEON, x86_64 SSE2, and WASM: [web demo](https://dkaraush.github.io/tlottie/examples/web/). All three are baseline features of their target, so there is no runtime dispatch.
 - Support of `fitz` modifier and color replacements.
 - Support of rendering into only alpha channel bitmap.
 - Safe. Lottie JSON is treated as untrusted input.
@@ -36,4 +36,4 @@ Frame time, mainly compared to [rlottie2019](https://github.com/TelegramMessenge
 - [linux x86](https://dkaraush.github.io/tlottie/benchmarks/linux.html)[^2]: **-72.6%** at 64px, **-49.8%** at 320px, **-32.8%** at 720px
 
 [^1]: Listed dependencies are only for GPU renderers, that are currently work in progress, expected to be useful only on large canvas sizes.
-[^2]: Tested on Threadripper running at all cores, a bit skeptical about such results.
+[^2]: Tested on Threadripper running at all cores, a bit skeptical about such results. Measured before the SSE2 backend existed, so these are tlottie's scalar path against rlottie's — x86_64 is faster than this now.

--- a/src/renderer/cpu/simd.rs
+++ b/src/renderer/cpu/simd.rs
@@ -98,6 +98,23 @@ pub(crate) fn fill_span_solid(dst: &mut [u32], cov: &[u8], sr: u32, sg: u32, sb:
       return;
     }
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let n = dst.len().min(cov.len());
+      let full = n - n % 4;
+      let (dst_v, dst_tail) = dst.split_at_mut(full);
+      let (cov_v, cov_tail) = cov.split_at(full.min(cov.len()));
+      // SAFETY: SSE2 is part of the x86_64 baseline and the cfg above
+      // additionally requires it to be statically enabled.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::fill_span_solid_sse2(dst_v, cov_v, sr, sg, sb, sa)
+      };
+      fill_span_solid_scalar(dst_tail, cov_tail, sr, sg, sb, sa);
+      return;
+    }
+  }
   fill_span_solid_scalar(dst, cov, sr, sg, sb, sa);
 }
 
@@ -192,6 +209,20 @@ pub(crate) fn fill_span_uniform(dst: &mut [u32], cov: u8, sr: u32, sg: u32, sb: 
       return;
     }
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let full = dst.len() - dst.len() % 4;
+      let (dst_v, dst_tail) = dst.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::fill_span_uniform_sse2(dst_v, ca, s_r, s_g, s_b)
+      };
+      fill_span_uniform_scalar(dst_tail, ca, s_r, s_g, s_b);
+      return;
+    }
+  }
   fill_span_uniform_scalar(dst, ca, s_r, s_g, s_b);
 }
 
@@ -251,6 +282,20 @@ pub(crate) fn linear_lut_fill(out: &mut [u32], lut: &[u32], row_base: f32, dt: f
       return;
     }
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if out.len() >= SIMD_MIN_SPAN {
+      let full = out.len() - out.len() % 4;
+      let (head, tail) = out.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::linear_lut_fill_sse2(head, lut, row_base, dt, x_start, scale)
+      };
+      linear_lut_fill_scalar(tail, lut, row_base, dt, x_start + full as f32, scale);
+      return;
+    }
+  }
   linear_lut_fill_scalar(out, lut, row_base, dt, x_start, scale);
 }
 
@@ -306,6 +351,20 @@ pub(crate) fn radial_lut_fill(out: &mut [u32], lut: &[u32], dd0x: f32, dd0y: f32
       return;
     }
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if out.len() >= SIMD_MIN_SPAN {
+      let full = out.len() - out.len() % 4;
+      let (head, tail) = out.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::radial_lut_fill_sse2(head, lut, dd0x, dd0y, da, db, inv_r, x_start, scale)
+      };
+      radial_lut_fill_scalar(tail, lut, dd0x, dd0y, da, db, inv_r, x_start + full as f32, scale);
+      return;
+    }
+  }
   radial_lut_fill_scalar(out, lut, dd0x, dd0y, da, db, inv_r, x_start, scale);
 }
 
@@ -355,6 +414,20 @@ pub(crate) fn focal_lut_fill(out: &mut [u32], lut: &[u32], g0x: f32, g0y: f32, s
       let full = out.len() - out.len() % 4;
       let (head, tail) = out.split_at_mut(full);
       wasm128::focal_lut_fill_wasm(head, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start, scale);
+      focal_lut_fill_scalar(tail, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start + full as f32, scale);
+      return;
+    }
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if out.len() >= SIMD_MIN_SPAN {
+      let full = out.len() - out.len() % 4;
+      let (head, tail) = out.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::focal_lut_fill_sse2(head, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start, scale)
+      };
       focal_lut_fill_scalar(tail, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start + full as f32, scale);
       return;
     }
@@ -433,6 +506,22 @@ pub(crate) fn composite_over_span(dst: &mut [u32], src: &[u32], k: u32) {
       let (dst_v, dst_tail) = dst.split_at_mut(full);
       let (src_v, src_tail) = src.split_at(full);
       wasm128::composite_over_wasm(dst_v, src_v, k);
+      composite_over_scalar(dst_tail, src_tail, k);
+      return;
+    }
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let n = dst.len().min(src.len());
+      let full = n - n % 4;
+      let (dst_v, dst_tail) = dst.split_at_mut(full);
+      let (src_v, src_tail) = src.split_at(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::composite_over_sse2(dst_v, src_v, k)
+      };
       composite_over_scalar(dst_tail, src_tail, k);
       return;
     }
@@ -517,6 +606,20 @@ pub(crate) fn linear_lut_over(dst: &mut [u32], lut: &[u32], row_base: f32, dt: f
       return;
     }
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let full = dst.len() - dst.len() % 4;
+      let (head, tail) = dst.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::linear_lut_over_sse2(head, lut, row_base, dt, x_start, scale)
+      };
+      linear_lut_over_scalar(tail, lut, row_base, dt, x_start + full as f32, scale);
+      return;
+    }
+  }
   linear_lut_over_scalar(dst, lut, row_base, dt, x_start, scale);
 }
 
@@ -558,6 +661,20 @@ pub(crate) fn radial_lut_over(dst: &mut [u32], lut: &[u32], dd0x: f32, dd0y: f32
       let full = dst.len() - dst.len() % 4;
       let (head, tail) = dst.split_at_mut(full);
       wasm128::radial_lut_over_wasm(head, lut, dd0x, dd0y, da, db, inv_r, x_start, scale);
+      radial_lut_over_scalar(tail, lut, dd0x, dd0y, da, db, inv_r, x_start + full as f32, scale);
+      return;
+    }
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let full = dst.len() - dst.len() % 4;
+      let (head, tail) = dst.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::radial_lut_over_sse2(head, lut, dd0x, dd0y, da, db, inv_r, x_start, scale)
+      };
       radial_lut_over_scalar(tail, lut, dd0x, dd0y, da, db, inv_r, x_start + full as f32, scale);
       return;
     }
@@ -607,6 +724,20 @@ pub(crate) fn focal_lut_over(dst: &mut [u32], lut: &[u32], g0x: f32, g0y: f32, s
       let full = dst.len() - dst.len() % 4;
       let (head, tail) = dst.split_at_mut(full);
       wasm128::focal_lut_over_wasm(head, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start, scale);
+      focal_lut_over_scalar(tail, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start + full as f32, scale);
+      return;
+    }
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  {
+    if dst.len() >= SIMD_MIN_SPAN {
+      let full = dst.len() - dst.len() % 4;
+      let (head, tail) = dst.split_at_mut(full);
+      // SAFETY: SSE2 is part of the x86_64 baseline.
+      #[allow(unsafe_code)]
+      unsafe {
+        sse2::focal_lut_over_sse2(head, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start, scale)
+      };
       focal_lut_over_scalar(tail, lut, g0x, g0y, sa, sb, dx, dy, a, inv2a, r, x_start + full as f32, scale);
       return;
     }
@@ -668,6 +799,18 @@ pub(crate) fn alpha_blend_solid(dst: &mut [u8], coverage: &[u8], alpha: u8) {
     alpha_blend_solid_scalar(tail, &coverage[full..n], alpha);
     return;
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_blend_solid_sse2(head, &coverage[..full], alpha)
+    };
+    alpha_blend_solid_scalar(tail, &coverage[full..n], alpha);
+    return;
+  }
   alpha_blend_solid_scalar(&mut dst[..n], &coverage[..n], alpha);
 }
 
@@ -696,6 +839,18 @@ pub(crate) fn alpha_blend_product(dst: &mut [u8], lhs: &[u8], rhs: &[u8]) {
     let full = n - n % 16;
     let (head, tail) = dst[..n].split_at_mut(full);
     wasm128::alpha_blend_product_wasm(head, &lhs[..full], &rhs[..full]);
+    alpha_blend_product_scalar(tail, &lhs[full..n], &rhs[full..n]);
+    return;
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_blend_product_sse2(head, &lhs[..full], &rhs[..full])
+    };
     alpha_blend_product_scalar(tail, &lhs[full..n], &rhs[full..n]);
     return;
   }
@@ -737,6 +892,18 @@ pub(crate) fn alpha_blend_uniform(dst: &mut [u8], coverage: u8, alpha: u8) {
     alpha_blend_uniform_scalar(tail, source);
     return;
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if dst.len() >= SIMD_MIN_SPAN {
+    let full = dst.len() - dst.len() % 16;
+    let (head, tail) = dst.split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_blend_uniform_sse2(head, source as u8)
+    };
+    alpha_blend_uniform_scalar(tail, source);
+    return;
+  }
   alpha_blend_uniform_scalar(dst, source);
 }
 
@@ -767,6 +934,18 @@ pub(crate) fn alpha_composite_over(dst: &mut [u8], src: &[u8], opacity: u8) {
     let full = n - n % 16;
     let (head, tail) = dst[..n].split_at_mut(full);
     wasm128::alpha_composite_over_wasm(head, &src[..full], opacity);
+    alpha_composite_over_scalar(tail, &src[full..n], opacity);
+    return;
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_composite_over_sse2(head, &src[..full], opacity)
+    };
     alpha_composite_over_scalar(tail, &src[full..n], opacity);
     return;
   }
@@ -801,6 +980,18 @@ pub(crate) fn alpha_multiply(dst: &mut [u8], factors: &[u8]) {
     alpha_multiply_scalar(tail, &factors[full..n]);
     return;
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_multiply_sse2(head, &factors[..full])
+    };
+    alpha_multiply_scalar(tail, &factors[full..n]);
+    return;
+  }
   alpha_multiply_scalar(&mut dst[..n], &factors[..n]);
 }
 
@@ -828,6 +1019,18 @@ pub(crate) fn alpha_matte(dst: &mut [u8], src: &[u8], opacity: u8, inverted: boo
     let full = n - n % 16;
     let (head, tail) = dst[..n].split_at_mut(full);
     wasm128::alpha_matte_wasm(head, &src[..full], opacity, inverted);
+    alpha_matte_scalar(tail, &src[full..n], opacity, inverted);
+    return;
+  }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_matte_sse2(head, &src[..full], opacity, inverted)
+    };
     alpha_matte_scalar(tail, &src[full..n], opacity, inverted);
     return;
   }
@@ -863,6 +1066,18 @@ pub(crate) fn alpha_mask_combine(dst: &mut [u8], src: &[u8], mode: u8, inverted:
     alpha_mask_combine_scalar(tail, &src[full..n], mode, inverted, opacity);
     return;
   }
+  #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+  if n >= SIMD_MIN_SPAN {
+    let full = n - n % 16;
+    let (head, tail) = dst[..n].split_at_mut(full);
+    // SAFETY: SSE2 is part of the x86_64 baseline.
+    #[allow(unsafe_code)]
+    unsafe {
+      sse2::alpha_mask_combine_sse2(head, &src[..full], mode, inverted, opacity)
+    };
+    alpha_mask_combine_scalar(tail, &src[full..n], mode, inverted, opacity);
+    return;
+  }
   alpha_mask_combine_scalar(&mut dst[..n], &src[..n], mode, inverted, opacity);
 }
 
@@ -887,6 +1102,10 @@ mod neon;
 #[cfg(all(target_arch = "wasm32", target_feature = "simd128"))]
 #[path = "simd/wasm.rs"]
 mod wasm128;
+
+#[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+#[path = "simd/sse2.rs"]
+mod sse2;
 
 #[cfg(test)]
 #[path = "tests/simd.rs"]

--- a/src/renderer/cpu/simd/sse2.rs
+++ b/src/renderer/cpu/simd/sse2.rs
@@ -1,0 +1,488 @@
+//! SSE2 kernels, 4 pixels (u32) / 16 pixels (Alpha8) per iteration.
+//!
+//! SSE2 is architecturally mandatory on x86_64, so — as with NEON on
+//! aarch64 — there is no runtime dispatch: the module is compiled in
+//! whenever the feature is statically present and the kernels are called
+//! unconditionally.
+//!
+//! Structurally this mirrors [`super::wasm128`], not the NEON backend:
+//! SSE2 has no `vld4`-style de-interleave (and `pshufb` is SSSE3, outside
+//! the x86_64 baseline), so the u16 kernels work on the natural
+//! interleaved layout — one `__m128i` = 4 pixels [R,G,B,A ×4], widened to
+//! two u16x8 halves (2 pixels each) with `punpck?bw` against zero and
+//! narrowed back with `packuswb`. Per-pixel factors (coverage, alpha) are
+//! replicated across each pixel's four channel lanes with `punpck`
+//! doubling and `pshuf?w`, both SSE2.
+//!
+//! Two signedness notes, since SSE2's integer min/max are signed:
+//! - `_mm_mullo_epi16` returns the low 16 product bits, so the u16 values
+//!   are bit-correct even where they exceed `i16::MAX` (`d * (inv+1)` peaks
+//!   at 65280); the following `_mm_srli_epi16` is a LOGICAL shift and
+//!   recovers the right magnitude.
+//! - `_mm_min_epi16`/`_mm_max_epi16` are signed, but every value they see
+//!   is already `<= 510` (`over` clamps `s + (d*(inv+1)>>8)`, and the mask
+//!   combine operates on 0..=255 alphas), so signed and unsigned agree.
+//!
+//! u16 lanes never overflow: every product is `(<=255)*(<=255) <= 65025`
+//! and div255's intermediate stays `<= 65407`.
+//!
+//! Unsafe is confined to [`load`], [`store`] and [`lut_gather`] — the only
+//! places that touch a raw pointer. Every other intrinsic here is
+//! register-to-register and is a safe call from inside a
+//! `#[target_feature(enable = "sse2")]` function.
+
+use core::arch::x86_64::{
+  __m128, __m128i, _mm_add_epi16, _mm_add_ps, _mm_and_ps, _mm_and_si128, _mm_andnot_ps, _mm_andnot_si128, _mm_castps_si128, _mm_castsi128_ps, _mm_cmpeq_epi32, _mm_cmpge_ps, _mm_cmplt_ps,
+  _mm_cmpunord_ps, _mm_cvtsi32_si128, _mm_cvttps_epi32, _mm_loadu_si128, _mm_max_epi16, _mm_max_ps, _mm_min_epi16, _mm_min_ps, _mm_movemask_epi8, _mm_mul_ps, _mm_mullo_epi16, _mm_or_ps, _mm_or_si128,
+  _mm_packus_epi16, _mm_set1_epi16, _mm_set1_epi32, _mm_set1_ps, _mm_setr_epi16, _mm_setr_ps, _mm_setzero_ps, _mm_setzero_si128, _mm_shufflehi_epi16, _mm_shufflelo_epi16, _mm_sqrt_ps, _mm_srli_epi16,
+  _mm_storeu_si128, _mm_sub_epi16, _mm_sub_ps, _mm_unpackhi_epi8, _mm_unpacklo_epi16, _mm_unpacklo_epi8,
+};
+
+/// Widens the low 8 bytes to u16 lanes.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lo(v: __m128i) -> __m128i {
+  _mm_unpacklo_epi8(v, _mm_setzero_si128())
+}
+
+/// Widens the high 8 bytes to u16 lanes.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn hi(v: __m128i) -> __m128i {
+  _mm_unpackhi_epi8(v, _mm_setzero_si128())
+}
+
+/// Exact `(n + 127) / 255` on u16 lanes (n <= 65025).
+#[inline]
+#[target_feature(enable = "sse2")]
+fn div255_round(n: __m128i) -> __m128i {
+  let t = _mm_add_epi16(n, _mm_set1_epi16(127));
+  let u = _mm_add_epi16(_mm_add_epi16(t, _mm_srli_epi16::<8>(t)), _mm_set1_epi16(1));
+  _mm_srli_epi16::<8>(u)
+}
+
+/// Premultiplied source-over on u16 channel lanes.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn over(d: __m128i, s: __m128i, inv: __m128i) -> __m128i {
+  _mm_min_epi16(_mm_add_epi16(s, _mm_srli_epi16::<8>(_mm_mullo_epi16(d, _mm_add_epi16(inv, _mm_set1_epi16(1))))), _mm_set1_epi16(255))
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
+fn alpha_over8(dst: __m128i, source: __m128i) -> __m128i {
+  over(dst, source, _mm_sub_epi16(_mm_set1_epi16(255), source))
+}
+
+/// Replicates a widened pixel-pair's alpha lanes (3 and 7) across each
+/// pixel's four channel lanes — the `pshufb` alpha broadcast, done after
+/// widening so plain SSE2 word shuffles suffice.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn splat_alpha(half: __m128i) -> __m128i {
+  _mm_shufflehi_epi16::<0xFF>(_mm_shufflelo_epi16::<0xFF>(half))
+}
+
+/// Unaligned 16-byte load.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn load(bytes: *const u8) -> __m128i {
+  // SAFETY: every caller passes a pointer to a `chunks_exact` window, so
+  // 16 readable bytes are guaranteed; `loadu` permits unaligned access.
+  #[allow(unsafe_code)]
+  unsafe {
+    _mm_loadu_si128(bytes.cast())
+  }
+}
+
+/// Unaligned 16-byte store.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn store(bytes: *mut u8, value: __m128i) {
+  // SAFETY: every caller passes a pointer to a `chunks_exact_mut` window,
+  // so 16 writable bytes are guaranteed; `storeu` permits unaligned access.
+  #[allow(unsafe_code)]
+  unsafe {
+    _mm_storeu_si128(bytes.cast(), value)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Alpha8 kernels — 16 pixels per iteration.
+// ---------------------------------------------------------------------------
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_blend_solid_sse2(dst: &mut [u8], coverage: &[u8], alpha: u8) {
+  let alpha = _mm_set1_epi16(i16::from(alpha));
+  for (dst, coverage) in dst.chunks_exact_mut(16).zip(coverage.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let c = load(coverage.as_ptr());
+    let sl = div255_round(_mm_mullo_epi16(lo(c), alpha));
+    let sh = div255_round(_mm_mullo_epi16(hi(c), alpha));
+    store(dst.as_mut_ptr(), _mm_packus_epi16(alpha_over8(lo(d), sl), alpha_over8(hi(d), sh)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_blend_product_sse2(dst: &mut [u8], lhs: &[u8], rhs: &[u8]) {
+  for ((dst, lhs), rhs) in dst.chunks_exact_mut(16).zip(lhs.chunks_exact(16)).zip(rhs.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let l = load(lhs.as_ptr());
+    let r = load(rhs.as_ptr());
+    let sl = div255_round(_mm_mullo_epi16(lo(l), lo(r)));
+    let sh = div255_round(_mm_mullo_epi16(hi(l), hi(r)));
+    store(dst.as_mut_ptr(), _mm_packus_epi16(alpha_over8(lo(d), sl), alpha_over8(hi(d), sh)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_blend_uniform_sse2(dst: &mut [u8], source: u8) {
+  let source = _mm_set1_epi16(i16::from(source));
+  for dst in dst.chunks_exact_mut(16) {
+    let d = load(dst.as_ptr());
+    store(dst.as_mut_ptr(), _mm_packus_epi16(alpha_over8(lo(d), source), alpha_over8(hi(d), source)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_composite_over_sse2(dst: &mut [u8], src: &[u8], opacity: u8) {
+  let opacity = _mm_set1_epi16(i16::from(opacity));
+  for (dst, src) in dst.chunks_exact_mut(16).zip(src.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let s = load(src.as_ptr());
+    let sl = div255_round(_mm_mullo_epi16(lo(s), opacity));
+    let sh = div255_round(_mm_mullo_epi16(hi(s), opacity));
+    store(dst.as_mut_ptr(), _mm_packus_epi16(alpha_over8(lo(d), sl), alpha_over8(hi(d), sh)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_multiply_sse2(dst: &mut [u8], factors: &[u8]) {
+  for (dst, factors) in dst.chunks_exact_mut(16).zip(factors.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let f = load(factors.as_ptr());
+    let l = div255_round(_mm_mullo_epi16(lo(d), lo(f)));
+    let h = div255_round(_mm_mullo_epi16(hi(d), hi(f)));
+    store(dst.as_mut_ptr(), _mm_packus_epi16(l, h));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_matte_sse2(dst: &mut [u8], src: &[u8], opacity: u8, inverted: bool) {
+  let opacity = _mm_set1_epi16(i16::from(opacity));
+  let full = _mm_set1_epi16(255);
+  for (dst, src) in dst.chunks_exact_mut(16).zip(src.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let s = load(src.as_ptr());
+    let mut fl = div255_round(_mm_mullo_epi16(lo(s), opacity));
+    let mut fh = div255_round(_mm_mullo_epi16(hi(s), opacity));
+    if inverted {
+      fl = _mm_sub_epi16(full, fl);
+      fh = _mm_sub_epi16(full, fh);
+    }
+    let l = div255_round(_mm_mullo_epi16(lo(d), fl));
+    let h = div255_round(_mm_mullo_epi16(hi(d), fh));
+    store(dst.as_mut_ptr(), _mm_packus_epi16(l, h));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn alpha_mask_combine_sse2(dst: &mut [u8], src: &[u8], mode: u8, inverted: bool, opacity: u8) {
+  let opacity = _mm_set1_epi16(i16::from(opacity));
+  let full = _mm_set1_epi16(255);
+  for (dst, src) in dst.chunks_exact_mut(16).zip(src.chunks_exact(16)) {
+    let d = load(dst.as_ptr());
+    let s = load(src.as_ptr());
+    let (dl, dh) = (lo(d), hi(d));
+    let (mut sl, mut sh) = (lo(s), hi(s));
+    if inverted {
+      sl = _mm_sub_epi16(full, sl);
+      sh = _mm_sub_epi16(full, sh);
+    }
+    let (cl, ch) = (div255_round(_mm_mullo_epi16(sl, opacity)), div255_round(_mm_mullo_epi16(sh, opacity)));
+    let combine = |old, contribution| match mode {
+      b's' => div255_round(_mm_mullo_epi16(old, _mm_sub_epi16(full, contribution))),
+      b'i' => div255_round(_mm_mullo_epi16(old, contribution)),
+      b'f' => _mm_sub_epi16(_mm_max_epi16(old, contribution), _mm_min_epi16(old, contribution)),
+      _ => _mm_add_epi16(contribution, div255_round(_mm_mullo_epi16(_mm_sub_epi16(full, contribution), old))),
+    };
+    store(dst.as_mut_ptr(), _mm_packus_epi16(combine(dl, cl), combine(dh, ch)));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// RGBA kernels — 4 pixels per iteration.
+// ---------------------------------------------------------------------------
+
+#[target_feature(enable = "sse2")]
+pub(super) fn fill_span_solid_sse2(dst: &mut [u32], cov: &[u8], sr: u32, sg: u32, sb: u32, sa: u32) {
+  // Source pattern per pixel is [R,G,B,255]: the 255 alpha lane makes
+  // `div255(255*ca+127) == ca` hold exactly, so one multiply yields
+  // s_r/s_g/s_b AND s_a = ca in their lanes.
+  let src = _mm_setr_epi16(sr as i16, sg as i16, sb as i16, 255, sr as i16, sg as i16, sb as i16, 255);
+  let sa_w = _mm_set1_epi16(sa as i16);
+  let full = _mm_set1_epi16(255);
+  for (dpx, cpx) in dst.chunks_exact_mut(4).zip(cov.chunks_exact(4)) {
+    let cw = u32::from_le_bytes(cpx.try_into().unwrap_or([0; 4]));
+    // rep4 without pshufb: byte-double then word-double turns the four
+    // coverage bytes into [c0 x4, c1 x4, c2 x4, c3 x4].
+    let c = _mm_cvtsi32_si128(cw as i32);
+    let doubled = _mm_unpacklo_epi8(c, c);
+    let crep = _mm_unpacklo_epi16(doubled, doubled);
+    let ca_lo = div255_round(_mm_mullo_epi16(lo(crep), sa_w));
+    let ca_hi = div255_round(_mm_mullo_epi16(hi(crep), sa_w));
+    let s_lo = div255_round(_mm_mullo_epi16(src, ca_lo));
+    let s_hi = div255_round(_mm_mullo_epi16(src, ca_hi));
+    let inv_lo = _mm_sub_epi16(full, ca_lo);
+    let inv_hi = _mm_sub_epi16(full, ca_hi);
+    let d = load(dpx.as_ptr().cast());
+    store(dpx.as_mut_ptr().cast(), _mm_packus_epi16(over(lo(d), s_lo, inv_lo), over(hi(d), s_hi, inv_hi)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn fill_span_uniform_sse2(dst: &mut [u32], ca: u32, s_r: u32, s_g: u32, s_b: u32) {
+  let s = _mm_setr_epi16(s_r as i16, s_g as i16, s_b as i16, ca as i16, s_r as i16, s_g as i16, s_b as i16, ca as i16);
+  let inv = _mm_set1_epi16(255 - ca as i16);
+  for dpx in dst.chunks_exact_mut(4) {
+    let d = load(dpx.as_ptr().cast());
+    store(dpx.as_mut_ptr().cast(), _mm_packus_epi16(over(lo(d), s, inv), over(hi(d), s, inv)));
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn composite_over_sse2(dst: &mut [u32], src: &[u32], k: u32) {
+  let kq = _mm_set1_epi16(k as i16);
+  let full = _mm_set1_epi16(255);
+  let zero = _mm_setzero_si128();
+  for (dpx, spx) in dst.chunks_exact_mut(4).zip(src.chunks_exact(4)) {
+    let d = load(dpx.as_ptr().cast());
+    let s = load(spx.as_ptr().cast());
+    // All four source pixels fully transparent: `over` is the identity on
+    // dst, so skip the round trip (matches the scalar `if s == 0`).
+    if _mm_movemask_epi8(_mm_cmpeq_epi32(s, zero)) == 0xFFFF {
+      continue;
+    }
+    let (s_lo_raw, s_hi_raw) = (lo(s), hi(s));
+    let s_lo = div255_round(_mm_mullo_epi16(s_lo_raw, kq));
+    let s_hi = div255_round(_mm_mullo_epi16(s_hi_raw, kq));
+    let inv_lo = _mm_sub_epi16(full, div255_round(_mm_mullo_epi16(splat_alpha(s_lo_raw), kq)));
+    let inv_hi = _mm_sub_epi16(full, div255_round(_mm_mullo_epi16(splat_alpha(s_hi_raw), kq)));
+    store(dpx.as_mut_ptr().cast(), _mm_packus_epi16(over(lo(d), s_lo, inv_lo), over(hi(d), s_hi, inv_hi)));
+  }
+}
+
+/// Clamp + LUT index conversion shared by the gradient kernels:
+/// `idx = trunc(clamp(t,0,1)*scale + 0.5)`, with lanes failing `valid`
+/// forced to the u32::MAX sentinel (LUT miss -> transparent 0). Matches
+/// the scalar `is_finite` gate + `as usize` truncation.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lut_indices(t: __m128, valid: __m128, scale: __m128) -> __m128i {
+  let tc = _mm_min_ps(_mm_max_ps(t, _mm_setzero_ps()), _mm_set1_ps(1.0));
+  let idx = _mm_cvttps_epi32(_mm_add_ps(_mm_mul_ps(tc, scale), _mm_set1_ps(0.5)));
+  let vi = _mm_castps_si128(valid);
+  _mm_or_si128(_mm_and_si128(vi, idx), _mm_andnot_si128(vi, _mm_set1_epi32(-1)))
+}
+
+/// 4 scalar LUT fetches (no gather in SSE2; sentinel misses -> 0).
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lut_gather(lut: &[u32], idx: __m128i) -> [u32; 4] {
+  let mut raw = [0u32; 4];
+  // SAFETY: `raw` is exactly four u32 = 16 writable bytes, and `storeu`
+  // permits unaligned access.
+  #[allow(unsafe_code)]
+  unsafe {
+    _mm_storeu_si128(raw.as_mut_ptr().cast(), idx)
+  };
+  let [i0, i1, i2, i3] = raw;
+  [
+    lut.get(i0 as usize).copied().unwrap_or(0),
+    lut.get(i1 as usize).copied().unwrap_or(0),
+    lut.get(i2 as usize).copied().unwrap_or(0),
+    lut.get(i3 as usize).copied().unwrap_or(0),
+  ]
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lut_store(chunk: &mut [u32], lut: &[u32], idx: __m128i) {
+  let [s0, s1, s2, s3] = lut_gather(lut, idx);
+  if let [o0, o1, o2, o3] = chunk {
+    (*o0, *o1, *o2, *o3) = (s0, s1, s2, s3);
+  }
+}
+
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lut_blend_over_k255(dpx: &mut [u32], lut: &[u32], idx: __m128i) {
+  // Source and destination are premultiplied RGBA bytes. k=255 means
+  // source channels pass through unchanged.
+  let src = lut_gather(lut, idx);
+  let full = _mm_set1_epi16(255);
+  let d = load(dpx.as_ptr().cast());
+  let s = load(src.as_ptr().cast());
+  let (s_lo, s_hi) = (lo(s), hi(s));
+  let inv_lo = _mm_sub_epi16(full, splat_alpha(s_lo));
+  let inv_hi = _mm_sub_epi16(full, splat_alpha(s_hi));
+  store(dpx.as_mut_ptr().cast(), _mm_packus_epi16(over(lo(d), s_lo, inv_lo), over(hi(d), s_hi, inv_hi)));
+}
+
+/// `|v|` — mask off the sign bit, matching `f32::abs`.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn abs_ps(v: __m128) -> __m128 {
+  _mm_and_ps(v, _mm_castsi128_ps(_mm_set1_epi32(0x7fff_ffff)))
+}
+
+/// Lane-wise `a.max(b)` with Rust's NaN semantics: `f32::max` returns the
+/// OTHER operand when one is NaN, while `maxps` unconditionally returns
+/// its second. The focal solver feeds this straight into an `is_finite`
+/// gate, so the difference is observable — select explicitly.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn max_ps_rust(a: __m128, b: __m128) -> __m128 {
+  let b_nan = _mm_cmpunord_ps(b, b);
+  _mm_or_ps(_mm_and_ps(b_nan, a), _mm_andnot_ps(b_nan, _mm_max_ps(a, b)))
+}
+
+/// Absolute device columns for one 4-lane chunk.
+#[inline]
+#[target_feature(enable = "sse2")]
+fn lane_columns(x_start: f32) -> __m128 {
+  _mm_add_ps(_mm_set1_ps(x_start), _mm_setr_ps(0.0, 1.0, 2.0, 3.0))
+}
+
+/// 4-lane linear gradient LUT fill: `t = row_base + X·dt` at absolute
+/// device column `X = x_start + lane` (segmentation-invariant), exactly
+/// the scalar form.
+#[target_feature(enable = "sse2")]
+pub(super) fn linear_lut_fill_sse2(out: &mut [u32], lut: &[u32], row_base: f32, dt: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let t0v = _mm_set1_ps(row_base);
+  let dtv = _mm_set1_ps(dt);
+  let four = _mm_set1_ps(4.0);
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in out.chunks_exact_mut(4) {
+    let t = _mm_add_ps(t0v, _mm_mul_ps(kf, dtv));
+    // is_finite parity: NaN fails the compare, ±inf fails |t|<inf.
+    let finite = _mm_cmplt_ps(abs_ps(t), inf);
+    lut_store(chunk, lut, lut_indices(t, finite, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}
+
+#[target_feature(enable = "sse2")]
+pub(super) fn linear_lut_over_sse2(dst: &mut [u32], lut: &[u32], row_base: f32, dt: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let t0v = _mm_set1_ps(row_base);
+  let dtv = _mm_set1_ps(dt);
+  let four = _mm_set1_ps(4.0);
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in dst.chunks_exact_mut(4) {
+    let t = _mm_add_ps(t0v, _mm_mul_ps(kf, dtv));
+    let finite = _mm_cmplt_ps(abs_ps(t), inf);
+    lut_blend_over_k255(chunk, lut, lut_indices(t, finite, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}
+
+/// 4-lane radial gradient LUT fill; mul + add (NOT fma) mirrors the
+/// scalar `ddx*ddx + ddy*ddy`, and `sqrtps` matches scalar `sqrt()`, so
+/// lanes agree with the `dd0 + X·d` scalar form bit-for-bit.
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse2")]
+pub(super) fn radial_lut_fill_sse2(out: &mut [u32], lut: &[u32], dd0x: f32, dd0y: f32, da: f32, db: f32, inv_r: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let (dav, dbv) = (_mm_set1_ps(da), _mm_set1_ps(db));
+  let (ddx0v, ddy0v) = (_mm_set1_ps(dd0x), _mm_set1_ps(dd0y));
+  let inv_rv = _mm_set1_ps(inv_r);
+  let four = _mm_set1_ps(4.0);
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in out.chunks_exact_mut(4) {
+    let ddx = _mm_add_ps(ddx0v, _mm_mul_ps(kf, dav));
+    let ddy = _mm_add_ps(ddy0v, _mm_mul_ps(kf, dbv));
+    let gg = _mm_add_ps(_mm_mul_ps(ddx, ddx), _mm_mul_ps(ddy, ddy));
+    let t = _mm_mul_ps(_mm_sqrt_ps(gg), inv_rv);
+    let finite = _mm_cmplt_ps(abs_ps(t), inf);
+    lut_store(chunk, lut, lut_indices(t, finite, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse2")]
+pub(super) fn radial_lut_over_sse2(dst: &mut [u32], lut: &[u32], dd0x: f32, dd0y: f32, da: f32, db: f32, inv_r: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let (dav, dbv) = (_mm_set1_ps(da), _mm_set1_ps(db));
+  let (ddx0v, ddy0v) = (_mm_set1_ps(dd0x), _mm_set1_ps(dd0y));
+  let inv_rv = _mm_set1_ps(inv_r);
+  let four = _mm_set1_ps(4.0);
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in dst.chunks_exact_mut(4) {
+    let ddx = _mm_add_ps(ddx0v, _mm_mul_ps(kf, dav));
+    let ddy = _mm_add_ps(ddy0v, _mm_mul_ps(kf, dbv));
+    let gg = _mm_add_ps(_mm_mul_ps(ddx, ddx), _mm_mul_ps(ddy, ddy));
+    let t = _mm_mul_ps(_mm_sqrt_ps(gg), inv_rv);
+    let finite = _mm_cmplt_ps(abs_ps(t), inf);
+    lut_blend_over_k255(chunk, lut, lut_indices(t, finite, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}
+
+/// 4-lane focal (highlight) radial LUT fill; keep the scalar absolute-X
+/// Horner rounding protocol so SIMD tails cannot introduce seams.
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse2")]
+pub(super) fn focal_lut_fill_sse2(out: &mut [u32], lut: &[u32], g0x: f32, g0y: f32, sa: f32, sb: f32, dx: f32, dy: f32, a: f32, inv2a: f32, r: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let (b0, db, d0, d1, d2) = super::focal_row_coefficients(g0x, g0y, sa, sb, dx, dy, a);
+  let (b0v, dbv) = (_mm_set1_ps(b0), _mm_set1_ps(db));
+  let (d0v, d1v, d2v) = (_mm_set1_ps(d0), _mm_set1_ps(d1), _mm_set1_ps(d2));
+  let inv2av = _mm_set1_ps(inv2a);
+  let rv = _mm_set1_ps(r);
+  let four = _mm_set1_ps(4.0);
+  let zero = _mm_setzero_ps();
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in out.chunks_exact_mut(4) {
+    let b = _mm_add_ps(b0v, _mm_mul_ps(kf, dbv));
+    let det = _mm_add_ps(d0v, _mm_mul_ps(kf, _mm_add_ps(d1v, _mm_mul_ps(kf, d2v))));
+    let sq = _mm_sqrt_ps(det);
+    let nb = _mm_sub_ps(zero, b);
+    let root = max_ps_rust(_mm_mul_ps(_mm_sub_ps(nb, sq), inv2av), _mm_mul_ps(_mm_add_ps(nb, sq), inv2av));
+    let valid = _mm_and_ps(_mm_and_ps(_mm_cmpge_ps(det, zero), _mm_cmpge_ps(_mm_mul_ps(rv, root), zero)), _mm_cmplt_ps(abs_ps(root), inf));
+    lut_store(chunk, lut, lut_indices(root, valid, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}
+
+#[allow(clippy::too_many_arguments)]
+#[target_feature(enable = "sse2")]
+pub(super) fn focal_lut_over_sse2(dst: &mut [u32], lut: &[u32], g0x: f32, g0y: f32, sa: f32, sb: f32, dx: f32, dy: f32, a: f32, inv2a: f32, r: f32, x_start: f32, scale: f32) {
+  let mut kf = lane_columns(x_start);
+  let (b0, db, d0, d1, d2) = super::focal_row_coefficients(g0x, g0y, sa, sb, dx, dy, a);
+  let (b0v, dbv) = (_mm_set1_ps(b0), _mm_set1_ps(db));
+  let (d0v, d1v, d2v) = (_mm_set1_ps(d0), _mm_set1_ps(d1), _mm_set1_ps(d2));
+  let inv2av = _mm_set1_ps(inv2a);
+  let rv = _mm_set1_ps(r);
+  let four = _mm_set1_ps(4.0);
+  let zero = _mm_setzero_ps();
+  let inf = _mm_set1_ps(f32::INFINITY);
+  let scalev = _mm_set1_ps(scale);
+  for chunk in dst.chunks_exact_mut(4) {
+    let b = _mm_add_ps(b0v, _mm_mul_ps(kf, dbv));
+    let det = _mm_add_ps(d0v, _mm_mul_ps(kf, _mm_add_ps(d1v, _mm_mul_ps(kf, d2v))));
+    let sq = _mm_sqrt_ps(det);
+    let nb = _mm_sub_ps(zero, b);
+    let root = max_ps_rust(_mm_mul_ps(_mm_sub_ps(nb, sq), inv2av), _mm_mul_ps(_mm_add_ps(nb, sq), inv2av));
+    let valid = _mm_and_ps(_mm_and_ps(_mm_cmpge_ps(det, zero), _mm_cmpge_ps(_mm_mul_ps(rv, root), zero)), _mm_cmplt_ps(abs_ps(root), inf));
+    lut_blend_over_k255(chunk, lut, lut_indices(root, valid, scalev));
+    kf = _mm_add_ps(kf, four);
+  }
+}


### PR DESCRIPTION
x86_64 currently falls back to the scalar path unconditionally, so desktop clients get none of the vector speedups aarch64 and wasm32 already have. This adds an SSE2 backend covering all 16 span kernels.

SSE2 is part of the x86_64 baseline, so this needs **no runtime dispatch** and mirrors the NEON structure: the module is compiled in whenever the feature is statically present, and the kernels are called directly.

### Design

The kernels follow `wasm128` rather than `neon`, because simd128 and SSE2 share the constraint that matters: there is no `vld4`-style de-interleave, and `pshufb` is SSSE3 — outside the baseline. So the u16 kernels work on the natural interleaved layout: widen with `punpck?bw` against zero, blend, narrow back with `packuswb`.

The two per-pixel factor broadcasts wasm does with `u8x16_swizzle` are done in plain SSE2:
- coverage `rep4` — `punpcklbw` doubling followed by `punpcklwd`
- alpha replication — `pshuflw`/`pshufhw` with imm `0xFF`, applied *after* widening, which is cheaper than a byte swizzle

Two signedness notes are documented in the module header: `_mm_mullo_epi16` keeps the low 16 product bits so values above `i16::MAX` (`d * (inv+1)` peaks at 65280) stay bit-correct under the following *logical* shift, and the signed `_mm_min_epi16`/`_mm_max_epi16` are safe because every value they see is already `<= 510`.

Unsafe is confined to `load`, `store` and `lut_gather` — the only functions touching a raw pointer. Everything else is register-to-register and is a safe call from inside a `#[target_feature]` fn.

### Correctness

All 16 kernels are bit-exact with the scalar oracle. The existing randomized differential tests cover them **unchanged** — they were previously vacuous on x86_64 (comparing scalar to scalar) and are now real.

Because "the tests pass" is weak evidence when the code might not be running, I verified by mutation that the new kernels actually execute: breaking `div255_round`, `over()` and `lut_indices` each fails exactly the expected subset of tests.

Additionally, 564 renders over 94 real Telegram sticker animations (3 frames x 2 sizes x 94 files) are **byte-identical** between the scalar and SSE2 builds.

### Benchmarks

Same 94-animation corpus, best-of-2, interleaved per file, x86_64:

| size | scalar | sse2 | delta |
|------|--------|------|-------|
| 64   | 372 ms | 356 ms | **-4.2%** |
| 320  | 1491 ms | 1187 ms | **-20.4%** |
| 720  | 4703 ms | 2971 ms | **-36.8%** |

I also tested lowering `SIMD_MIN_SPAN` to 8 for x86, since the threshold comment attributes 16 to ARM measurements: +1.6% at 64px, -2.1% at 320px. Not a win, so the shared threshold is untouched.

### One deliberate divergence from wasm128

The focal solver's root selection uses an explicit NaN-aware max rather than a bare `maxps`.

Rust's `f32::max` returns the *other* operand when one side is NaN; `maxps` unconditionally returns its second operand. That value feeds straight into the `is_finite` gate, so the difference is observable — a lane where the scalar path picks a finite root can end up NaN (and therefore transparent) under a naive vector max.

Worth noting that **`wasm128` has the same mismatch in the opposite direction** (`f32x4_max` propagates NaN, so it diverges from `f32::max` on either operand). I have left that alone here since it is pre-existing and out of scope, but it looks like a genuine latent bug rather than an intentional relaxation — happy to send a separate fix if you agree.

### Not included

`fill_span_opaque` (the NEON large-canvas opaque fast path) has no SSE2 counterpart here. The scalar run-detection path already collapses interiors to `fill()`, and matching wasm's proven kernel surface keeps this reviewable. Easy follow-up if the large-canvas numbers justify it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)