### PR TITLE
Add BGRA output as a parse-time channel order

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Library for drawing [lottie animations](https://en.wikipedia.org/wiki/Lottie_(fi
 - Micro-optimized and [benchmarked](#benchmarks) across 17k+ animations from Telegram, against [rlottie](https://github.com/Samsung/rlottie) and [thorvg](https://github.com/thorvg/thorvg).
 - SIMD on ARM NEON, and WASM: [web demo](https://dkaraush.github.io/tlottie/examples/web/).
 - Support of `fitz` modifier and color replacements.
+- RGBA or BGRA output, chosen per instance at parse time and free at render time — desktop compositors (Qt `ARGB32_Premultiplied`, DXGI `B8G8R8A8_UNORM`, Cairo `ARGB32`) take BGRA without a conversion pass.
 - Support of rendering into only alpha channel bitmap.
 - Safe. Lottie JSON is treated as untrusted input.
 - Zero dependencies[^1].

--- a/include/tlottie.h
+++ b/include/tlottie.h
@@ -33,6 +33,18 @@ typedef struct TLottieColorReplacement {
   uint32_t target_color;
 } TLottieColorReplacement;
 
+/*
+ * Byte order of every pixel an instance renders. Selected once at parse
+ * time by pre-swapping the model's colors, so it costs nothing per frame.
+ */
+enum TlottieChannelOrder {
+  /* 0xAABBGGRR words: [R, G, B, A] bytes. Android ARGB_8888. */
+  TLOTTIE_CHANNEL_RGBA = 0,
+  /* 0xAARRGGBB words: [B, G, R, A] bytes. Qt ARGB32_Premultiplied,
+     DXGI B8G8R8A8_UNORM, Cairo ARGB32. */
+  TLOTTIE_CHANNEL_BGRA = 1,
+};
+
 enum TlottieStatus {
   TLOTTIE_OK = 0,
   TLOTTIE_ERROR_INVALID_ARGUMENT = -1,
@@ -47,6 +59,9 @@ TLottieInstance *tlottie_new(const uint8_t *json_ptr, size_t json_len);
  * Like tlottie_new, with parse-time customization. Layer prefixes do not
  * include the legacy trailing "**"; matching and color replacement happen
  * once while the instance is created.
+ *
+ * channel_order is one of TLOTTIE_CHANNEL_*. Color replacements are always
+ * given as 0xAARRGGBB, whichever order is selected.
  */
 TLottieInstance *tlottie_new_with_options(
     const uint8_t *json_ptr,
@@ -55,7 +70,8 @@ TLottieInstance *tlottie_new_with_options(
     const TLottieLayerColorReplacement *replacements,
     size_t replacements_len,
     const TLottieColorReplacement *color_replacements,
-    size_t color_replacements_len);
+    size_t color_replacements_len,
+    uint32_t channel_order);
 
 /* NULL is accepted. Other pointers must have come from tlottie_new. */
 void tlottie_drop(TLottieInstance *renderer);

--- a/src/bindings/c_api.rs
+++ b/src/bindings/c_api.rs
@@ -2,7 +2,7 @@
 
 #![allow(unsafe_code)]
 
-use crate::{CPURenderer, Composition, FitzModifier, LayerColorReplacement, Limits, ParseOptions, RenderOptions, SourceColorReplacement};
+use crate::{CPURenderer, ChannelOrder, Composition, FitzModifier, LayerColorReplacement, Limits, ParseOptions, RenderOptions, SourceColorReplacement};
 
 /// One constructor-time layer-prefix color override.
 #[repr(C)]
@@ -35,13 +35,18 @@ pub struct TLottieInstance {
 /// `json_ptr..json_ptr+json_len` must be readable for the duration of the call.
 #[no_mangle]
 pub unsafe extern "C" fn tlottie_new(json_ptr: *const u8, json_len: usize) -> *mut TLottieInstance {
-  unsafe { tlottie_new_with_options(json_ptr, json_len, 0, core::ptr::null(), 0, core::ptr::null(), 0) }
+  unsafe { tlottie_new_with_options(json_ptr, json_len, 0, core::ptr::null(), 0, core::ptr::null(), 0, 0) }
 }
 
 /// Parses Lottie JSON with a Fitz modifier and layer-prefix color overrides.
 ///
 /// `fitz_modifier` is one of `TLOTTIE_FITZ_*`. Prefix strings are matched
 /// directly against layer `nm` values and need no trailing `**`.
+///
+/// `channel_order` is one of `TLOTTIE_CHANNEL_*` and selects the byte order
+/// of every pixel this instance renders. It is applied once here, so it costs
+/// nothing per frame; color replacements are still given as `0xAARRGGBB`
+/// regardless of the order chosen.
 ///
 /// # Safety
 /// The JSON and every prefix byte range must be readable for this call.
@@ -54,11 +59,15 @@ pub unsafe extern "C" fn tlottie_new_with_options(
   replacements_len: usize,
   color_replacements_ptr: *const TLottieColorReplacement,
   color_replacements_len: usize,
+  channel_order: u32,
 ) -> *mut TLottieInstance {
   if json_ptr.is_null() {
     return core::ptr::null_mut();
   }
   let Some(fitz_modifier) = FitzModifier::from_u32(fitz_modifier) else {
+    return core::ptr::null_mut();
+  };
+  let Some(channel_order) = ChannelOrder::from_u32(channel_order) else {
     return core::ptr::null_mut();
   };
   if replacements_len != 0 && replacements_ptr.is_null() {
@@ -107,6 +116,7 @@ pub unsafe extern "C" fn tlottie_new_with_options(
     fitz_modifier,
     layer_color_replacements,
     source_color_replacements,
+    channel_order,
   };
   match Composition::parse_with_options(json, &Limits::default(), &options) {
     Ok(comp) => Box::into_raw(Box::new(TLottieInstance { renderer: CPURenderer::new(comp) })),

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -73,6 +73,7 @@ fn parse_render_args(args: &[String]) -> Result<RenderArgs<'_>, String> {
         }
       }
       "--alpha-only" | "--single-color" => options.alpha_only = true,
+      "--bgra" => parse_options.channel_order = tlottie::ChannelOrder::Bgra,
       "--fitz" => parse_options.fitz_modifier = parse_fitz(args.next().ok_or("--fitz requires a value")?)?,
       "--layer-color" => parse_options
         .layer_color_replacements
@@ -179,6 +180,7 @@ fn bench_cmd(args: &[String]) -> ExitCode {
         options.curve_tolerance = value;
       }
       "--alpha-only" | "--single-color" => options.alpha_only = true,
+      "--bgra" => parse_options.channel_order = tlottie::ChannelOrder::Bgra,
       "--fitz" => {
         let Some(value) = args.next() else {
           eprintln!("bench: --fitz requires a value");

--- a/src/composition/mod.rs
+++ b/src/composition/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod model;
 pub(crate) mod options;
 pub(crate) mod parse;
 pub(crate) mod property;
+pub(crate) mod swizzle;

--- a/src/composition/model.rs
+++ b/src/composition/model.rs
@@ -36,6 +36,9 @@ pub struct Composition {
   pub(crate) layers: Vec<Layer>,
   /// Precomp assets, looked up by `Layer::ref_id`.
   pub(crate) assets: Vec<Asset>,
+  /// Byte order the model's colors are stored in. Everything except the luma
+  /// matte is channel-order agnostic, so this is only consulted there.
+  pub(crate) channel_order: crate::composition::options::ChannelOrder,
 }
 
 impl Composition {

--- a/src/composition/options.rs
+++ b/src/composition/options.rs
@@ -63,6 +63,36 @@ pub struct SourceColorReplacement {
   pub target_color: u32,
 }
 
+/// Byte order of the premultiplied pixels a renderer writes.
+///
+/// The blend pipeline itself is channel-order agnostic — every stage reads a
+/// channel at bit N and writes it back at bit N — so the order is applied
+/// once, by pre-swapping the parsed model's colors. Rendering therefore costs
+/// exactly the same in either order.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[repr(u32)]
+pub enum ChannelOrder {
+  /// `0xAABBGGRR` words: `[R, G, B, A]` bytes in little-endian memory.
+  /// Matches Android's `Bitmap.Config.ARGB_8888`.
+  #[default]
+  Rgba = 0,
+  /// `0xAARRGGBB` words: `[B, G, R, A]` bytes in little-endian memory.
+  /// Matches Qt's `QImage::Format_ARGB32_Premultiplied`, Direct2D /
+  /// DXGI `B8G8R8A8_UNORM`, and Cairo's `CAIRO_FORMAT_ARGB32` — i.e. what
+  /// desktop compositors take without a conversion pass.
+  Bgra = 1,
+}
+
+impl ChannelOrder {
+  pub(crate) fn from_u32(value: u32) -> Option<Self> {
+    match value {
+      0 => Some(Self::Rgba),
+      1 => Some(Self::Bgra),
+      _ => None,
+    }
+  }
+}
+
 /// Options applied while a [`crate::Composition`] is parsed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ParseOptions {
@@ -72,4 +102,7 @@ pub struct ParseOptions {
   pub layer_color_replacements: Vec<LayerColorReplacement>,
   /// Exact source-color replacements, resolved once during parsing.
   pub source_color_replacements: Vec<SourceColorReplacement>,
+  /// Byte order of the rendered pixels. Applied after every color
+  /// replacement, so replacement colors are still matched as `0xAARRGGBB`.
+  pub channel_order: ChannelOrder,
 }

--- a/src/composition/parse.rs
+++ b/src/composition/parse.rs
@@ -1562,7 +1562,7 @@ pub(crate) fn parse_composition(bytes: &[u8], limits: &Limits, options: &ParseOp
     apply_layer_replacements(&mut asset.layers, &options.layer_color_replacements);
   }
 
-  Ok(Composition {
+  let mut composition = Composition {
     width: width as u32,
     height: height as u32,
     frame_rate: frame_rate as f32,
@@ -1571,7 +1571,14 @@ pub(crate) fn parse_composition(bytes: &[u8], limits: &Limits, options: &ParseOp
     static_content,
     layers,
     assets,
-  })
+    channel_order: options.channel_order,
+  };
+  // Last step, deliberately: color replacements above match and supply
+  // `0xAARRGGBB`, so the swap has to happen after they have been resolved.
+  if options.channel_order == crate::composition::options::ChannelOrder::Bgra {
+    crate::composition::swizzle::swap_red_blue(&mut composition);
+  }
+  Ok(composition)
 }
 
 #[cfg(test)]

--- a/src/composition/swizzle.rs
+++ b/src/composition/swizzle.rs
@@ -1,0 +1,104 @@
+//! Red/blue channel swap applied once, at parse time.
+//!
+//! The CPU pipeline never interprets a channel's meaning: coverage blending,
+//! gradient interpolation, matte modulation and every SIMD kernel read a
+//! channel at bit N and write the result back at bit N. The single exception
+//! is the luma matte, whose Rec.601 weights are channel-specific; it reads
+//! [`crate::model::Composition::channel_order`] instead.
+//!
+//! So emitting BGRA costs nothing per pixel — pre-swap the handful of colors
+//! in the model and every downstream stage produces `0xAARRGGBB` words on its
+//! own. This runs AFTER color replacements so callers still match and supply
+//! replacement colors as `0xAARRGGBB`, exactly as they do for RGBA output.
+
+use crate::model::{Asset, Composition, FloatList, Layer, Shape};
+use crate::property::Property;
+
+/// Swaps red and blue in every color the model carries.
+pub(crate) fn swap_red_blue(comp: &mut Composition) {
+  for layer in comp.layers.iter_mut() {
+    swap_layer(layer);
+  }
+  for asset in comp.assets.iter_mut() {
+    swap_asset(asset);
+  }
+}
+
+fn swap_asset(asset: &mut Asset) {
+  for layer in asset.layers.iter_mut() {
+    swap_layer(layer);
+  }
+}
+
+fn swap_layer(layer: &mut Layer) {
+  if let Some((_, _, color)) = layer.solid.as_mut() {
+    core::mem::swap(&mut color.r, &mut color.b);
+  }
+  swap_shapes(&mut layer.shapes);
+}
+
+fn swap_shapes(shapes: &mut [Shape]) {
+  for shape in shapes.iter_mut() {
+    match shape {
+      Shape::Group(group) => swap_shapes(&mut group.shapes),
+      Shape::Fill(fill) => swap_color_property(&mut fill.color),
+      Shape::Stroke(stroke) => swap_color_property(&mut stroke.color),
+      Shape::GradientFill(gradient) => {
+        let count = gradient.color_count;
+        map_property(&mut gradient.stops, &mut |stops| swap_stops(stops, count));
+      }
+      Shape::GradientStroke(gradient) => {
+        let count = gradient.color_count;
+        map_property(&mut gradient.stops, &mut |stops| swap_stops(stops, count));
+      }
+      // No color of their own; geometry and modifiers only. Repeater holds a
+      // transform and copy counts — the shapes it repeats are its siblings.
+      Shape::Path(_) | Shape::Rect(_) | Shape::Ellipse(_) | Shape::Trim(_) | Shape::Polystar(_) | Shape::RoundCorners(_) | Shape::Repeater(_) => {}
+    }
+  }
+}
+
+fn swap_color_property(color: &mut Property<crate::math::Color>) {
+  map_property(color, &mut |value| core::mem::swap(&mut value.r, &mut value.b));
+}
+
+/// Stop data is `color_count * [offset, r, g, b]` followed by optional
+/// `[offset, alpha]` pairs — only the color quads are touched, so the alpha
+/// ramp that follows them is left exactly as parsed.
+fn swap_stops(stops: &mut FloatList, color_count: usize) {
+  for index in 0..color_count {
+    let base = index.saturating_mul(4);
+    let (Some(red), Some(blue)) = (base.checked_add(1), base.checked_add(3)) else {
+      continue;
+    };
+    let (Some(&r), Some(&b)) = (stops.0.get(red), stops.0.get(blue)) else {
+      continue;
+    };
+    if let Some(slot) = stops.0.get_mut(red) {
+      *slot = b;
+    }
+    if let Some(slot) = stops.0.get_mut(blue) {
+      *slot = r;
+    }
+  }
+}
+
+/// Applies `f` to every value a property can take: the static value, or each
+/// keyframe's value together with its explicit segment end.
+fn map_property<T>(property: &mut Property<T>, f: &mut impl FnMut(&mut T)) {
+  match property {
+    Property::Static(value) => f(value),
+    Property::Animated(timeline) => {
+      f(&mut timeline.first.value);
+      if let Some(end) = timeline.first.end.as_mut() {
+        f(end);
+      }
+      for keyframe in timeline.rest.iter_mut() {
+        f(&mut keyframe.value);
+        if let Some(end) = keyframe.end.as_mut() {
+          f(end);
+        }
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod internal {
   pub use crate::renderer::frame::*;
 }
 
-pub use composition::options::{FitzModifier, LayerColorReplacement, ParseOptions, SourceColorReplacement};
+pub use composition::options::{ChannelOrder, FitzModifier, LayerColorReplacement, ParseOptions, SourceColorReplacement};
 pub use error::{Error, JsonErrorKind, Limit, Result};
 pub use limits::Limits;
 pub use model::Composition;

--- a/src/renderer/cpu/backend.rs
+++ b/src/renderer/cpu/backend.rs
@@ -179,7 +179,7 @@ impl CPURenderer {
         };
         let _source_dirty = self.surface_dirty.pop().unwrap_or_else(DirtyBox::empty);
         let source_rows = self.surface_rows.pop().unwrap_or_default();
-        apply_matte(&mut target, &source, kind, source_opacity);
+        apply_matte(&mut target, &source, kind, source_opacity, self.comp.channel_order);
         let width = self.width;
         composite_over_rows(self.active(), &target, width, &target_rows, target_dirty, opacity);
         if !target_dirty.is_empty() {

--- a/src/renderer/cpu/executor.rs
+++ b/src/renderer/cpu/executor.rs
@@ -473,7 +473,7 @@ impl RenderCtx<'_> {
             for_rows_boxed(&mut buf_a, w, da, |y, row| {
               let lo = y * w + da.x0;
               if let Some(src_row) = buf_b.get(lo..lo + row.len()) {
-                apply_matte(row, src_row, kind, opacity_byte(src_op) as u8);
+                apply_matte(row, src_row, kind, opacity_byte(src_op) as u8, self.comp.channel_order);
               }
             });
             scratch.put_u32(buf_b);
@@ -798,15 +798,15 @@ pub(crate) fn modulate(pixels: &mut [u32], mask: &[u8]) {
 
 /// Applies a matte source (`src`) onto `dst` premultiplied pixels.
 /// kind: 1 alpha, 2 inverted alpha, 3 luma, 4 inverted luma.
-pub(crate) fn apply_matte(dst: &mut [u32], src: &[u32], kind: u8, source_opacity: u8) {
+pub(crate) fn apply_matte(dst: &mut [u32], src: &[u32], kind: u8, source_opacity: u8, order: crate::ChannelOrder) {
   for (d, &s) in dst.iter_mut().zip(src.iter()) {
     let alpha = (s >> 24) & 0xff;
     let scaled_alpha = (alpha * u32::from(source_opacity) + 127) / 255;
     let factor = match kind {
       1 => scaled_alpha,
       2 => 255 - scaled_alpha,
-      3 => luma_premult(s),
-      _ => 255 - luma_premult(s),
+      3 => luma_premult(s, order),
+      _ => 255 - luma_premult(s, order),
     };
     if factor == 255 {
       continue;
@@ -827,20 +827,30 @@ pub(crate) fn apply_matte(dst: &mut [u32], src: &[u32], kind: u8, source_opacity
 /// Luma of a premultiplied pixel, rlottie semantics: unpremultiply, then
 /// Rec.601 weights on the straight color (the matte's own alpha does not
 /// scale the luma).
-fn luma_premult(p: u32) -> u32 {
+///
+/// The ONLY place in the pipeline where a channel's identity matters, since
+/// the Rec.601 weights differ per channel: under [`ChannelOrder::Bgra`] the
+/// low byte holds blue and bits 16..24 hold red, so the two weights trade
+/// places. Everything else blends channels independently and needs no such
+/// knowledge.
+fn luma_premult(p: u32, order: crate::ChannelOrder) -> u32 {
   let a = (p >> 24) & 0xff;
   if a == 0 {
     return 0;
   }
-  let mut r = p & 0xff;
+  let mut low = p & 0xff;
   let mut g = (p >> 8) & 0xff;
-  let mut b = (p >> 16) & 0xff;
+  let mut high = (p >> 16) & 0xff;
   if a != 255 {
-    r = (r * 255) / a;
+    low = (low * 255) / a;
     g = (g * 255) / a;
-    b = (b * 255) / a;
+    high = (high * 255) / a;
   }
-  ((r * 299 + g * 587 + b * 114) / 1000).min(255)
+  let (low_weight, high_weight) = match order {
+    crate::ChannelOrder::Rgba => (299, 114),
+    crate::ChannelOrder::Bgra => (114, 299),
+  };
+  ((low * low_weight + g * 587 + high * high_weight) / 1000).min(255)
 }
 
 /// Composites premultiplied `src` over `dst` with a global opacity factor.

--- a/src/renderer/cpu/tests/mask_bounds.rs
+++ b/src/renderer/cpu/tests/mask_bounds.rs
@@ -70,6 +70,7 @@ fn empty_comp() -> Composition {
     static_content: false,
     layers: Vec::new(),
     assets: Vec::new(),
+    channel_order: Default::default(),
   }
 }
 

--- a/tests/channel_order.rs
+++ b/tests/channel_order.rs
@@ -1,0 +1,149 @@
+//! `ChannelOrder::Bgra` must be exactly `ChannelOrder::Rgba` with red and
+//! blue exchanged — nothing else may move.
+//!
+//! This is the whole safety net for the parse-time swap: if any color-bearing
+//! node in the model is missed (a gradient stop quad, a keyframe's explicit
+//! `end` value, a solid layer, a nested group), the two renders stop being
+//! byte-swaps of each other and these tests fail.
+
+use tlottie::{ChannelOrder, Composition, Limits, ParseOptions, RenderOptions};
+
+/// `0xAABBGGRR` -> `0xAARRGGBB`; green and alpha stay put.
+fn swap_rb(pixel: u32) -> u32 {
+  (pixel & 0xff00_ff00) | ((pixel & 0x00ff_0000) >> 16) | ((pixel & 0x0000_00ff) << 16)
+}
+
+fn render(json: &[u8], order: ChannelOrder, frame: f32, size: u32) -> Option<Vec<u32>> {
+  let options = ParseOptions {
+    channel_order: order,
+    ..ParseOptions::default()
+  };
+  let comp = Composition::parse_with_options(json, &Limits::default(), &options).ok()?;
+  let mut renderer = tlottie::CPURenderer::new(comp);
+  let mut pixels = vec![0u32; (size as usize) * (size as usize)];
+  renderer.render(frame, &mut pixels, size, size, RenderOptions::default()).ok()?;
+  Some(pixels)
+}
+
+/// Returns the number of pixels that break the invariant.
+fn mismatches(json: &[u8], frame: f32, size: u32) -> Option<usize> {
+  let rgba = render(json, ChannelOrder::Rgba, frame, size)?;
+  let bgra = render(json, ChannelOrder::Bgra, frame, size)?;
+  Some(rgba.iter().zip(bgra.iter()).filter(|(r, b)| swap_rb(**r) != **b).count())
+}
+
+/// Solid fill, stroke, a linear gradient with an alpha ramp, a solid layer,
+/// and a luma track matte — one of each color-bearing node, animated so the
+/// keyframe paths are exercised too.
+const MIXED: &str = r##"{
+  "v":"5.5.7","fr":30,"ip":0,"op":30,"w":64,"h":64,
+  "layers":[
+    {"ddd":0,"ind":0,"ty":4,"nm":"matte-source","td":1,"sr":1,
+     "ks":{"o":{"a":0,"k":100},"p":{"a":0,"k":[32,32,0]},"a":{"a":0,"k":[0,0,0]},"s":{"a":0,"k":[100,100,100]}},
+     "shapes":[
+       {"ty":"gr","it":[
+         {"ty":"rc","p":{"a":0,"k":[0,0]},"s":{"a":0,"k":[52,52]},"r":{"a":0,"k":0}},
+         {"ty":"gf","t":1,"s":{"a":0,"k":[-26,0]},"e":{"a":0,"k":[26,0]},
+          "g":{"p":2,"k":{"a":0,"k":[0,0.95,0.05,0.05, 1,0.05,0.05,0.95]}},
+          "o":{"a":0,"k":100}},
+         {"ty":"tr","p":{"a":0,"k":[0,0]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"o":{"a":0,"k":100}}
+       ]}
+     ],"ip":0,"op":30,"st":0},
+    {"ddd":0,"ind":1,"ty":4,"nm":"matted","tt":3,"sr":1,
+     "ks":{"o":{"a":0,"k":100},"p":{"a":0,"k":[32,32,0]},"a":{"a":0,"k":[0,0,0]},"s":{"a":0,"k":[100,100,100]}},
+     "shapes":[
+       {"ty":"gr","it":[
+         {"ty":"rc","p":{"a":0,"k":[0,0]},"s":{"a":0,"k":[40,40]},"r":{"a":0,"k":4}},
+         {"ty":"gf","t":1,"s":{"a":0,"k":[0,0]},"e":{"a":0,"k":[40,0]},
+          "g":{"p":3,"k":{"a":0,"k":[0,0.9,0.1,0.2, 0.5,0.2,0.8,0.3, 1,0.1,0.2,0.95, 0,1, 0.5,0.4, 1,0.8]}},
+          "o":{"a":0,"k":100}},
+         {"ty":"st","c":{"a":1,"k":[
+             {"t":0,"s":[0.95,0.25,0.1,1],"e":[0.1,0.3,0.9,1]},
+             {"t":30,"s":[0.1,0.3,0.9,1]}]},
+          "o":{"a":0,"k":100},"w":{"a":0,"k":3},"lc":1,"lj":1},
+         {"ty":"tr","p":{"a":0,"k":[0,0]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"o":{"a":0,"k":100}}
+       ]}
+     ],"ip":0,"op":30,"st":0},
+    {"ddd":0,"ind":2,"ty":1,"nm":"solid","sr":1,"sc":"#3c78d8","sw":64,"sh":64,
+     "ks":{"o":{"a":0,"k":80},"p":{"a":0,"k":[32,32,0]},"a":{"a":0,"k":[32,32,0]},"s":{"a":0,"k":[100,100,100]}},
+     "ip":0,"op":30,"st":0},
+    {"ddd":0,"ind":3,"ty":4,"nm":"fill","sr":1,
+     "ks":{"o":{"a":0,"k":100},"p":{"a":0,"k":[32,32,0]},"a":{"a":0,"k":[0,0,0]},"s":{"a":0,"k":[100,100,100]}},
+     "shapes":[
+       {"ty":"gr","it":[
+         {"ty":"el","p":{"a":0,"k":[0,0]},"s":{"a":0,"k":[50,50]}},
+         {"ty":"fl","c":{"a":0,"k":[0.85,0.15,0.35,1]},"o":{"a":0,"k":100}},
+         {"ty":"tr","p":{"a":0,"k":[0,0]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"o":{"a":0,"k":100}}
+       ]}
+     ],"ip":0,"op":30,"st":0}
+  ]
+}"##;
+
+#[test]
+fn bgra_is_rgba_with_red_and_blue_swapped() {
+  for frame in [0.0, 7.0, 15.5, 29.0] {
+    let bad = mismatches(MIXED.as_bytes(), frame, 64).expect("fixture renders in both orders");
+    assert_eq!(bad, 0, "frame {frame} broke the swap invariant on {bad} pixels");
+  }
+}
+
+#[test]
+fn swap_is_not_a_no_op() {
+  // Guards the test itself: if the animation were greyscale the invariant
+  // above would hold trivially and prove nothing.
+  let rgba = render(MIXED.as_bytes(), ChannelOrder::Rgba, 7.0, 64).expect("renders");
+  let bgra = render(MIXED.as_bytes(), ChannelOrder::Bgra, 7.0, 64).expect("renders");
+  assert!(
+    rgba.iter().zip(bgra.iter()).any(|(r, b)| r != b),
+    "fixture has no red/blue asymmetry, so it cannot detect a missed swap"
+  );
+}
+
+/// Sweeps a fixture corpus when `TLOTTIE_FIXTURES` points at a directory of
+/// Lottie JSON. Skipped otherwise, so CI stays self-contained.
+#[test]
+fn corpus_upholds_the_swap_invariant() {
+  let Ok(root) = std::env::var("TLOTTIE_FIXTURES") else {
+    eprintln!("TLOTTIE_FIXTURES unset - skipping corpus sweep");
+    return;
+  };
+  let mut files = Vec::new();
+  collect_json(std::path::Path::new(&root), &mut files);
+  assert!(!files.is_empty(), "no .json fixtures under {root}");
+
+  let (mut checked, mut skipped) = (0usize, 0usize);
+  let mut failures = Vec::new();
+  for path in &files {
+    let Ok(bytes) = std::fs::read(path) else {
+      skipped += 1;
+      continue;
+    };
+    match mismatches(&bytes, 0.0, 96) {
+      Some(0) => checked += 1,
+      Some(bad) => {
+        checked += 1;
+        if failures.len() < 20 {
+          failures.push(format!("{} ({bad} px)", path.display()));
+        }
+      }
+      // Does not parse in either order - not this feature's business.
+      None => skipped += 1,
+    }
+  }
+  eprintln!("corpus: {checked} checked, {skipped} unparsable, {} broken", failures.len());
+  assert!(failures.is_empty(), "swap invariant broken by:\n{}", failures.join("\n"));
+}
+
+fn collect_json(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+  let Ok(entries) = std::fs::read_dir(dir) else {
+    return;
+  };
+  for entry in entries.flatten() {
+    let path = entry.path();
+    if path.is_dir() {
+      collect_json(&path, out);
+    } else if path.extension().is_some_and(|e| e == "json") {
+      out.push(path);
+    }
+  }
+}


### PR DESCRIPTION
tlottie emits `0xAABBGGRR` words — Android's `Bitmap.Config.ARGB_8888` byte order. Desktop wants the opposite: Qt's `QImage::Format_ARGB32_Premultiplied`, DXGI's `B8G8R8A8_UNORM` and Cairo's `ARGB32` are all `0xAARRGGBB`. So every desktop consumer — Telegram Desktop as much as the UWP client this came from — currently pays a full-surface swizzle on every frame, or has to convert at upload.

### The approach

Rather than a cargo feature or a second set of kernels, this leans on a property the pipeline already has: **nothing in it interprets what a channel means**. Coverage blending, gradient interpolation, matte modulation and all sixteen SIMD kernels read a channel at bit N and write the result back at bit N.

So swapping red and blue *once*, in the parsed model, makes the whole renderer emit BGRA by itself. `ChannelOrder` lives on `ParseOptions`, right next to the fitz modifier and colour replacements that are already folded into the immutable model at parse time.

That buys three things a build-time switch would not:
- **per instance**, so a single build serves Android and desktop
- **free at render time** — no per-pixel branch, no duplicated codegen
- no cargo feature-unification surprises for anyone depending on tlottie twice

Diff is ~100 lines, and the renderer, the SIMD kernels and the blend math are all untouched.

### Two details worth your attention

**The swap runs last**, after colour replacements. Callers therefore still match and supply replacement colours as `0xAARRGGBB` whichever order they pick — the option changes output, not the API's colour convention.

**`luma_premult` is the one exception** to channel-agnosticism, because Rec.601 weights differ per channel. Under `Bgra` the red and blue weights trade places; it reads `Composition::channel_order`. This is the only hot-path change in the PR, and it only runs on luma track mattes.

`tlottie_new_with_options` gains a `channel_order` parameter, which is an **ABI change** — flagging it explicitly in case you would rather have a separate entry point.

### Validation

`tests/channel_order.rs` asserts the invariant that BGRA output is *exactly* RGBA with red and blue exchanged. Any colour-bearing node missed by the swap — a gradient stop quad, a keyframe's explicit `end` value, a solid layer, a nested group — breaks that invariant.

The fixture covers a fill, a stroke, gradient stops with an alpha ramp, an animated colour with an explicit keyframe end, a solid layer, and a luma track matte. A second test asserts the fixture genuinely has red/blue asymmetry, so the invariant cannot pass vacuously.

Both were mutation-checked rather than assumed: reverting the luma weight swap fails them (1908 pixels). Worth saying that the first version of that fixture put the `tt` layer at index 0, so it had no matte source and the luma path was never exercised — the mutation check is what caught it.

Set `TLOTTIE_FIXTURES` to a corpus directory for a full sweep; it skips when unset so CI stays self-contained. Over the 16,393 Telegram fixtures:

```
corpus: 16393 checked, 0 unparsable, 0 broken
```

### Cost

None measurable, as the design predicts. Over 260 fixtures:

| size | RGBA | BGRA | delta |
|------|------|------|-------|
| 128 | 1673.1 ms | 1665.2 ms | -0.47% |
| 320 | 3481.3 ms | 3482.1 ms | +0.02% |
| 720 | 7807.8 ms | 7807.5 ms | -0.00% |

`--bgra` is wired into the CLI's `render` and `bench` so this is reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)