### PR TITLE
Add an opt-in no_std build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "futures-core"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
@@ -133,7 +148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -319,6 +334,7 @@ version = "0.1.0"
 dependencies = [
  "ash",
  "glow",
+ "hashbrown 0.15.5",
  "naga",
  "wasm-bindgen",
  "web-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,18 +14,29 @@ path = "src/cli/main.rs"
 required-features = ["cli"]
 
 [features]
-default = ["cpu"]
+default = ["cpu", "std"]
 cpu = []
-vulkan = ["cpu", "dep:ash", "dep:naga"]
-opengl = ["cpu", "dep:glow"]
+# Linking against the standard library. On by default, so existing consumers
+# are unaffected; turning it off (--no-default-features) builds the renderer
+# against core + alloc only. Motivation is not size — LTO already strips
+# unreachable std — but toolchain and import surface: a no_std build needs
+# neither a nightly toolchain nor a tier-3 target, and imports nothing beyond
+# the allocator, which matters for sandboxed hosts such as an app container.
+std = []
+vulkan = ["cpu", "std", "dep:ash", "dep:naga"]
+opengl = ["cpu", "std", "dep:glow"]
 webgl = ["opengl", "wasm", "dep:wasm-bindgen", "dep:web-sys"]
-cli = ["cpu"]
+cli = ["cpu", "std"]
 c-api = ["cpu"]
-wasm = ["cpu"]
+wasm = ["cpu", "std"]
 
 [dependencies]
 ash = { version = "0.37.3", default-features = false, features = ["loaded"], optional = true }
 glow = { version = "0.18", optional = true }
+# Only pulled in by no_std builds: `alloc` has no hash map, and this is the
+# implementation `std::collections::HashMap` already wraps, so the caches
+# behave identically either way. Default builds stay dependency-free.
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher", "inline-more"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2.126", optional = true }
@@ -58,3 +69,9 @@ codegen-units = 1
 inherits = "release"
 opt-level = "z"
 strip = "symbols"
+
+# no_std builds must abort on panic: unwinding needs a personality routine
+# that only std provides. Build the staticlib with `--profile release-nostd`.
+[profile.release-nostd]
+inherits = "release"
+panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,7 @@ strip = "symbols"
 [profile.release-nostd]
 inherits = "release"
 panic = "abort"
+# Line tables so Rust frames symbolicate in a crash dump. On MSVC this lands
+# in the PDB, not the binary, so the shipped library does not grow; without it
+# a crash inside the renderer is a bare address.
+debug = "line-tables-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,3 @@ strip = "symbols"
 [profile.release-nostd]
 inherits = "release"
 panic = "abort"
-# Line tables so Rust frames symbolicate in a crash dump. On MSVC this lands
-# in the PDB, not the binary, so the shipped library does not grow; without it
-# a crash inside the renderer is a bare address.
-debug = "line-tables-only"

--- a/src/bindings/c_api.rs
+++ b/src/bindings/c_api.rs
@@ -3,6 +3,9 @@
 #![allow(unsafe_code)]
 
 use crate::{CPURenderer, Composition, FitzModifier, LayerColorReplacement, Limits, ParseOptions, RenderOptions, SourceColorReplacement};
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 
 /// One constructor-time layer-prefix color override.
 #[repr(C)]

--- a/src/bindings/wasm.rs
+++ b/src/bindings/wasm.rs
@@ -1,5 +1,8 @@
 #![allow(unsafe_code)]
 
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::vec::Vec;
 use std::alloc::{alloc, dealloc, Layout};
 
 use crate::{CPURenderer, Composition, FitzModifier, LayerColorReplacement, Limits, ParseOptions, RenderOptions};
@@ -35,7 +38,7 @@ pub extern "C" fn tlottie_alloc(len: usize) -> *mut u8 {
       // SAFETY: layout is valid and non-zero-sized.
       unsafe { alloc(layout) }
     }
-    _ => std::ptr::null_mut(),
+    _ => core::ptr::null_mut(),
   }
 }
 
@@ -81,33 +84,33 @@ pub unsafe extern "C" fn tlottie_new_with_options(
   replacements_len: usize,
 ) -> *mut Instance {
   if json_ptr.is_null() {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   }
   let Some(fitz_modifier) = FitzModifier::from_u32(fitz_modifier) else {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   };
   if replacements_len != 0 && replacements_ptr.is_null() {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   }
   // SAFETY: caller contract — the range is a live allocation.
-  let json = unsafe { std::slice::from_raw_parts(json_ptr, json_len) };
+  let json = unsafe { core::slice::from_raw_parts(json_ptr, json_len) };
   let raw_replacements = if replacements_len == 0 {
     &[]
   } else {
-    unsafe { std::slice::from_raw_parts(replacements_ptr, replacements_len) }
+    unsafe { core::slice::from_raw_parts(replacements_ptr, replacements_len) }
   };
   let mut layer_color_replacements = Vec::with_capacity(raw_replacements.len());
   for replacement in raw_replacements {
     if replacement.layer_name_prefix_len != 0 && replacement.layer_name_prefix.is_null() {
-      return std::ptr::null_mut();
+      return core::ptr::null_mut();
     }
     let bytes = if replacement.layer_name_prefix_len == 0 {
       &[]
     } else {
-      unsafe { std::slice::from_raw_parts(replacement.layer_name_prefix, replacement.layer_name_prefix_len) }
+      unsafe { core::slice::from_raw_parts(replacement.layer_name_prefix, replacement.layer_name_prefix_len) }
     };
-    let Ok(prefix) = std::str::from_utf8(bytes) else {
-      return std::ptr::null_mut();
+    let Ok(prefix) = core::str::from_utf8(bytes) else {
+      return core::ptr::null_mut();
     };
     layer_color_replacements.push(LayerColorReplacement {
       layer_name_prefix: prefix.to_owned(),
@@ -126,7 +129,7 @@ pub unsafe extern "C" fn tlottie_new_with_options(
       rgba: Vec::new(),
       alpha8: Vec::new(),
     })),
-    Err(_) => std::ptr::null_mut(),
+    Err(_) => core::ptr::null_mut(),
   }
 }
 
@@ -196,13 +199,13 @@ pub unsafe extern "C" fn tlottie_render(inst: *mut Instance, frame: f32, width: 
 pub unsafe extern "C" fn tlottie_render_with_options(inst: *mut Instance, frame: f32, width: u32, height: u32, antialias: u32, curve_tolerance: f32) -> *const u8 {
   // SAFETY: caller contract.
   let Some(inst) = (unsafe { inst.as_mut() }) else {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   };
   if !curve_tolerance.is_finite() || curve_tolerance <= 0.0 {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   }
   let Some(px) = (width as usize).checked_mul(height as usize) else {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   };
   // Resize-only: render() fully overwrites all px pixels, so re-zeroing
   // an already-sized buffer is pure memset waste (profiled ~1MB/frame).
@@ -225,10 +228,10 @@ pub unsafe extern "C" fn tlottie_render_with_options(inst: *mut Instance, frame:
     )
     .is_err()
   {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   }
   let Some(bytes) = px.checked_mul(4) else {
-    return std::ptr::null_mut();
+    return core::ptr::null_mut();
   };
   // Same resize-only rationale: the conversion loop below writes every
   // byte of the RGBA buffer.
@@ -251,10 +254,10 @@ pub unsafe extern "C" fn tlottie_render_alpha8(inst: *mut Instance, frame: f32, 
 #[no_mangle]
 pub unsafe extern "C" fn tlottie_render_alpha8_with_options(inst: *mut Instance, frame: f32, width: u32, height: u32, antialias: u32, curve_tolerance: f32) -> *const u8 {
   let Some(inst) = (unsafe { inst.as_mut() }) else {
-    return std::ptr::null();
+    return core::ptr::null();
   };
   if render_alpha8(inst, frame, width, height, antialias, curve_tolerance).is_none() {
-    return std::ptr::null();
+    return core::ptr::null();
   }
   inst.alpha8.as_ptr()
 }
@@ -271,13 +274,13 @@ pub unsafe extern "C" fn tlottie_render_alpha8_color(inst: *mut Instance, frame:
 #[no_mangle]
 pub unsafe extern "C" fn tlottie_render_alpha8_color_with_options(inst: *mut Instance, frame: f32, width: u32, height: u32, antialias: u32, color: u32, curve_tolerance: f32) -> *const u8 {
   let Some(inst) = (unsafe { inst.as_mut() }) else {
-    return std::ptr::null();
+    return core::ptr::null();
   };
   let Some(px) = render_alpha8(inst, frame, width, height, antialias, curve_tolerance) else {
-    return std::ptr::null();
+    return core::ptr::null();
   };
   let Some(bytes) = px.checked_mul(4) else {
-    return std::ptr::null();
+    return core::ptr::null();
   };
   if inst.rgba.len() != bytes {
     inst.rgba.resize(bytes, 0);

--- a/src/compat.rs
+++ b/src/compat.rs
@@ -1,0 +1,242 @@
+//! The two things `core` + `alloc` do not provide on their own.
+//!
+//! Kept in one place so the rest of the crate reads the same in both
+//! configurations: everything else already works from `alloc` paths, which
+//! are valid in `std` builds too.
+
+#[cfg(not(feature = "std"))]
+pub(crate) use hashbrown::{HashMap, HashSet};
+/// `alloc` has no hash map. `std::collections::HashMap` already wraps
+/// hashbrown, so the two are the same implementation and the caches keyed by
+/// this type behave — and perform — identically either way.
+#[cfg(feature = "std")]
+pub(crate) use std::collections::{HashMap, HashSet};
+
+/// Float methods that live in `std` because they lower to libm calls.
+///
+/// `core` covers the pure-arithmetic ones already (`min`, `max`, `clamp`,
+/// `is_finite`, `to_radians`, …); only the transcendental and rounding
+/// operations need an implementation. In `std` builds this trait is not
+/// compiled at all — the inherent methods are used, so behaviour is
+/// bit-identical rather than merely equivalent.
+#[cfg(not(feature = "std"))]
+pub(crate) use libm_shim::FloatExt;
+
+#[cfg(not(feature = "std"))]
+mod libm_shim {
+  // Every symbol below is part of the C runtime already linked by any host
+  // capable of running this crate; declaring them keeps the no_std build
+  // dependency-free rather than pulling in a Rust libm reimplementation.
+  #![allow(unsafe_code)]
+
+  extern "C" {
+    fn sqrtf(x: f32) -> f32;
+    fn floorf(x: f32) -> f32;
+    fn ceilf(x: f32) -> f32;
+    fn roundf(x: f32) -> f32;
+    fn truncf(x: f32) -> f32;
+    fn sinf(x: f32) -> f32;
+    fn cosf(x: f32) -> f32;
+    fn tanf(x: f32) -> f32;
+    fn atan2f(y: f32, x: f32) -> f32;
+    fn powf(x: f32, y: f32) -> f32;
+    fn fmodf(x: f32, y: f32) -> f32;
+    fn floor(x: f64) -> f64;
+  }
+
+  /// Rounding and transcendental float operations for `no_std` builds.
+  pub(crate) trait FloatExt {
+    /// Square root.
+    fn sqrt(self) -> Self;
+    /// Absolute value.
+    fn abs(self) -> Self;
+    /// Largest integer not greater than self.
+    fn floor(self) -> Self;
+    /// Smallest integer not less than self.
+    fn ceil(self) -> Self;
+    /// Nearest integer, halfway cases away from zero.
+    fn round(self) -> Self;
+    /// Integer part.
+    fn trunc(self) -> Self;
+    /// Fractional part, keeping the sign of self.
+    fn fract(self) -> Self;
+    /// Sine of an angle in radians.
+    fn sin(self) -> Self;
+    /// Cosine of an angle in radians.
+    fn cos(self) -> Self;
+    /// Tangent of an angle in radians.
+    fn tan(self) -> Self;
+    /// Sine and cosine together, matching `f32::sin_cos`.
+    fn sin_cos(self) -> (Self, Self)
+    where
+      Self: Sized;
+    /// Four-quadrant arctangent of `self / other`.
+    fn atan2(self, other: Self) -> Self;
+    /// Self raised to a floating point power.
+    fn powf(self, n: Self) -> Self;
+    /// Least nonnegative remainder of `self (mod rhs)`.
+    fn rem_euclid(self, rhs: Self) -> Self;
+  }
+
+  impl FloatExt for f32 {
+    #[inline]
+    fn sqrt(self) -> Self {
+      unsafe { sqrtf(self) }
+    }
+
+    // Sign-bit mask rather than a libm call: exact, branchless, and correct
+    // for NaN and both zeroes.
+    #[inline]
+    fn abs(self) -> Self {
+      Self::from_bits(self.to_bits() & 0x7fff_ffff)
+    }
+
+    #[inline]
+    fn floor(self) -> Self {
+      unsafe { floorf(self) }
+    }
+
+    #[inline]
+    fn ceil(self) -> Self {
+      unsafe { ceilf(self) }
+    }
+
+    #[inline]
+    fn round(self) -> Self {
+      unsafe { roundf(self) }
+    }
+
+    #[inline]
+    fn trunc(self) -> Self {
+      unsafe { truncf(self) }
+    }
+
+    // core's definition exactly: self - trunc(self).
+    #[inline]
+    fn fract(self) -> Self {
+      self - FloatExt::trunc(self)
+    }
+
+    #[inline]
+    fn sin(self) -> Self {
+      unsafe { sinf(self) }
+    }
+
+    #[inline]
+    fn cos(self) -> Self {
+      unsafe { cosf(self) }
+    }
+
+    #[inline]
+    fn tan(self) -> Self {
+      unsafe { tanf(self) }
+    }
+
+    #[inline]
+    fn sin_cos(self) -> (Self, Self) {
+      (FloatExt::sin(self), FloatExt::cos(self))
+    }
+
+    #[inline]
+    fn atan2(self, other: Self) -> Self {
+      unsafe { atan2f(self, other) }
+    }
+
+    #[inline]
+    fn powf(self, n: Self) -> Self {
+      unsafe { powf(self, n) }
+    }
+
+    // Mirrors core's definition; `%` on floats lowers to fmodf either way.
+    #[inline]
+    fn rem_euclid(self, rhs: Self) -> Self {
+      let r = unsafe { fmodf(self, rhs) };
+      if r < 0.0 {
+        r + FloatExt::abs(rhs)
+      } else {
+        r
+      }
+    }
+  }
+
+  impl FloatExt for f64 {
+    #[inline]
+    fn sqrt(self) -> Self {
+      // Only `floor` is needed on f64 today; the rest are unreachable but
+      // must exist for the impl to be complete.
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn abs(self) -> Self {
+      Self::from_bits(self.to_bits() & 0x7fff_ffff_ffff_ffff)
+    }
+
+    #[inline]
+    fn floor(self) -> Self {
+      unsafe { floor(self) }
+    }
+
+    #[inline]
+    fn ceil(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn round(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn trunc(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn fract(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn sin(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn cos(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn tan(self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn sin_cos(self) -> (Self, Self) {
+      (unimplemented_f64(), unimplemented_f64())
+    }
+
+    #[inline]
+    fn atan2(self, _other: Self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn powf(self, _n: Self) -> Self {
+      unimplemented_f64()
+    }
+
+    #[inline]
+    fn rem_euclid(self, _rhs: Self) -> Self {
+      unimplemented_f64()
+    }
+  }
+
+  /// f64 operations the renderer never performs. Returning a quiet NaN keeps
+  /// the crate's no-panic contract intact if one is ever reached.
+  #[inline]
+  fn unimplemented_f64() -> f64 {
+    f64::NAN
+  }
+}

--- a/src/composition/json.rs
+++ b/src/composition/json.rs
@@ -8,10 +8,12 @@
 //! - values we don't care about are *skipped*, not validated in depth —
 //!   full validation happens where a subtree is actually parsed.
 
+use crate::compat::HashMap;
 use crate::error::{Error, JsonErrorKind, Limit, Result};
-use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
-use std::rc::Rc;
+use alloc::format;
+use alloc::rc::Rc;
+use alloc::string::String;
+use core::cell::{Cell, RefCell};
 
 pub(crate) struct Cursor<'a> {
   bytes: &'a [u8],

--- a/src/composition/model.rs
+++ b/src/composition/model.rs
@@ -1,8 +1,13 @@
 //! The immutable parsed animation model. Shared (`Arc`) across render
 //! instances; render-time state lives elsewhere.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::math::{Color, Vec2};
 use crate::property::{Lerp, Property};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// Raw float list (gradient stop data); lerps pointwise when lengths match.
 #[derive(Debug, Clone, Default, PartialEq)]

--- a/src/composition/options.rs
+++ b/src/composition/options.rs
@@ -63,6 +63,8 @@ pub struct SourceColorReplacement {
   pub target_color: u32,
 }
 
+use alloc::string::String;
+use alloc::vec::Vec;
 /// Options applied while a [`crate::Composition`] is parsed.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct ParseOptions {

--- a/src/composition/parse.rs
+++ b/src/composition/parse.rs
@@ -8,6 +8,8 @@
 //! Unsupported shape/layer types are skipped silently for now; the
 //! supported-feature report lands with a later phase.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::composition::options::{LayerColorReplacement, ParseOptions, SourceColorReplacement};
 use crate::error::{Error, JsonErrorKind, Limit, Result};
 use crate::json::Cursor;
@@ -19,6 +21,9 @@ use crate::model::{
 };
 use crate::property::{Easing, Keyframe, Lerp, Property, Timeline};
 use crate::stroke::{Cap, Join};
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::vec::Vec;
 
 /// Maximum nesting of `gr` shape groups (separate from raw JSON depth).
 const MAX_GROUP_DEPTH: usize = 32;

--- a/src/composition/property.rs
+++ b/src/composition/property.rs
@@ -4,6 +4,7 @@
 //! interned easing LUTs come with the performance phases.
 
 use crate::math::{Color, Vec2};
+use alloc::vec::Vec;
 
 /// Temporal easing between two keyframes: a cubic bezier through (0,0),
 /// (ox,oy), (ix,iy), (1,1) mapping normalized time to normalized progress.

--- a/src/composition/tests/parse.rs
+++ b/src/composition/tests/parse.rs
@@ -1,5 +1,8 @@
 use super::*;
 use crate::FitzModifier;
+use alloc::format;
+use alloc::string::String;
+use alloc::vec;
 
 const MINIMAL: &str = r#"{"v":"5.5.2","fr":60,"ip":0,"op":180,"w":512,"h":512,"nm":"t","layers":[]}"#;
 

--- a/src/composition/tests/property.rs
+++ b/src/composition/tests/property.rs
@@ -1,5 +1,7 @@
 use super::*;
 use crate::composition::property::{Easing, Keyframe, Property, Timeline};
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn animated(kfs: Vec<Keyframe<f32>>) -> Property<f32> {
   let mut it = kfs.into_iter();

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,6 +79,9 @@ impl fmt::Display for Error {
   }
 }
 
+// core has no Error trait, so this is the one API difference between the two
+// configurations. Display, Debug and the enum itself are unchanged.
+#[cfg(feature = "std")]
 impl std::error::Error for Error {}
 
 /// Convenience alias: `tlottie::Result<T>` = `Result<T, tlottie::Error>`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,9 +12,23 @@
 // opt-in FFI, and opt-in Vulkan modules locally allow only the operations
 // required at those boundaries. `deny` (not `forbid`) lets those modules opt
 // in explicitly while keeping the rest of the crate safe by default.
+#![cfg_attr(not(feature = "std"), no_std)]
 #![deny(unsafe_code)]
 #![deny(missing_docs)]
 
+// Available in std builds too, so the rest of the crate can name `alloc`
+// paths unconditionally and read identically in both configurations.
+extern crate alloc;
+
+#[cfg(all(not(feature = "std"), not(feature = "hashbrown")))]
+compile_error!("building without `std` needs a hash map: add `--features hashbrown` (see the `compat` module)");
+
+// Only a staticlib handed to a C host needs these; a Rust binary linking the
+// crate brings its own.
+#[cfg(all(not(feature = "std"), feature = "c-api"))]
+mod no_std_runtime;
+
+mod compat;
 mod composition;
 mod error;
 mod math;

--- a/src/math.rs
+++ b/src/math.rs
@@ -1,5 +1,8 @@
 //! Small single-precision geometry and math primitives.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
+
 /// 2D point / vector.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(crate) struct Vec2 {

--- a/src/no_std_runtime.rs
+++ b/src/no_std_runtime.rs
@@ -1,0 +1,77 @@
+//! The lang items a `no_std` staticlib has to carry.
+//!
+//! A library would normally leave both to the final binary, but a C or C++
+//! host cannot define Rust lang items, so the `c-api` staticlib provides them
+//! itself. `std` builds are unaffected — this module does not exist there.
+//!
+//! Both are deliberately minimal: the allocator forwards to the C runtime the
+//! host already links, and panics abort. The crate is written not to panic
+//! (malformed input returns [`crate::Error`], and `panic`/`unwrap`/`expect`
+//! /`indexing_slicing` are denied by lint), so the handler is a backstop, not
+//! a control-flow path.
+
+#![allow(unsafe_code)]
+
+use core::alloc::{GlobalAlloc, Layout};
+
+extern "C" {
+  fn malloc(size: usize) -> *mut u8;
+  fn free(ptr: *mut u8);
+  fn abort() -> !;
+}
+
+/// Forwards to the host C runtime's allocator.
+///
+/// `malloc` only promises fundamental alignment (16 bytes on the targets this
+/// crate builds for), so anything stricter is over-allocated and hand-aligned,
+/// with the original pointer stashed in the word below the aligned address.
+/// The renderer never asks for more than 16 today; the slow path exists so a
+/// future over-aligned type cannot silently corrupt the heap.
+struct HostAlloc;
+
+/// Fundamental alignment guaranteed by the C runtime.
+const MALLOC_ALIGN: usize = 16;
+
+unsafe impl GlobalAlloc for HostAlloc {
+  unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+    if layout.align() <= MALLOC_ALIGN {
+      return unsafe { malloc(layout.size()) };
+    }
+    // Room for the payload, the worst-case adjustment, and the saved pointer.
+    let Some(padded) = layout.size().checked_add(layout.align()).and_then(|n| n.checked_add(core::mem::size_of::<usize>())) else {
+      return core::ptr::null_mut();
+    };
+    let raw = unsafe { malloc(padded) };
+    if raw.is_null() {
+      return raw;
+    }
+    let base = raw as usize;
+    let reserved = base.wrapping_add(core::mem::size_of::<usize>());
+    let aligned = reserved.wrapping_add(layout.align() - 1) & !(layout.align() - 1);
+    // SAFETY: `aligned` is at least one usize above `raw` and inside the
+    // padded allocation, so the slot below it is ours to write.
+    unsafe { (aligned as *mut usize).sub(1).write(base) };
+    aligned as *mut u8
+  }
+
+  unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+    if layout.align() <= MALLOC_ALIGN {
+      unsafe { free(ptr) };
+      return;
+    }
+    // SAFETY: alloc wrote the original pointer immediately below the address
+    // it returned, and layout.align() matches the allocating call.
+    let base = unsafe { (ptr as *mut usize).sub(1).read() };
+    unsafe { free(base as *mut u8) };
+  }
+}
+
+#[global_allocator]
+static ALLOCATOR: HostAlloc = HostAlloc;
+
+#[panic_handler]
+fn panic(_info: &core::panic::PanicInfo) -> ! {
+  // No message: formatting one would pull in core::fmt's machinery, which is
+  // most of what a no_std build is trying to leave behind.
+  unsafe { abort() }
+}

--- a/src/renderer/cpu/alpha_backend.rs
+++ b/src/renderer/cpu/alpha_backend.rs
@@ -2,6 +2,7 @@
 
 use crate::model::FillRule;
 use crate::renderer::frame::{Composite, FrameRenderer, Geometry, GradientKind, GradientPaint, Paint, Rule};
+use alloc::vec::Vec;
 
 use super::executor::{mode_s_wins, pack_span, unpack_span, CovEntry, PlaneData, RenderScratch, SPAN_CAPTURE_MAX};
 

--- a/src/renderer/cpu/backend.rs
+++ b/src/renderer/cpu/backend.rs
@@ -4,6 +4,7 @@
 
 use crate::model::FillRule;
 use crate::renderer::frame::{Composite, FrameRenderer, Geometry, GradientKind, GradientPaint, Paint, Rule};
+use alloc::vec::Vec;
 
 use super::executor::{apply_matte, mode_s_wins, modulate, Canvas, CovCache, DirtyBox, GradientMap, GradientMapKind, RowBounds};
 use super::CPURenderer;

--- a/src/renderer/cpu/canvas.rs
+++ b/src/renderer/cpu/canvas.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec::Vec;
 
 /// Inclusive rectangle containing every pixel written to a canvas.
 /// Pixels outside it remain transparent.

--- a/src/renderer/cpu/cells.rs
+++ b/src/renderer/cpu/cells.rs
@@ -15,6 +15,7 @@
 
 use crate::geometry::Contour;
 use crate::model::FillRule;
+use alloc::vec::Vec;
 
 /// Subpixel bits (24.8 fixed point, FreeType's PIXEL_BITS = 8).
 const PIX_B: i32 = 8;

--- a/src/renderer/cpu/coverage.rs
+++ b/src/renderer/cpu/coverage.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec::Vec;
 
 /// Paint bbox extent (px, max dimension) ABOVE which the sparse cell/span
 /// engine rasterizes instead of the dense accumulator. The threshold is
@@ -184,7 +185,7 @@ pub(crate) struct CovEntry {
 /// geometries per loop and full keys would dwarf the coverage payload).
 /// Eviction: whole-cache clear on budget overflow — periodic animations
 /// refill within one loop, and the budget bounds per-instance memory.
-pub(super) type CoverageMap = std::collections::HashMap<u128, CovEntry, core::hash::BuildHasherDefault<CoverageKeyHasher>>;
+pub(super) type CoverageMap = crate::compat::HashMap<u128, CovEntry, core::hash::BuildHasherDefault<CoverageKeyHasher>>;
 
 /// Coverage keys are already two independently mixed 64-bit content hashes.
 /// Running SipHash over them at every lookup is redundant and shows up on
@@ -379,15 +380,22 @@ impl CovCache {
 
   pub(crate) fn set_budget_for_canvas(&mut self, w: usize, h: usize) {
     // Development hook for overriding the three size-class cache budgets.
-    static OVERRIDE: std::sync::OnceLock<Option<[usize; 3]>> = std::sync::OnceLock::new();
-    let ov = OVERRIDE.get_or_init(|| {
-      let v = std::env::var("TLOTTIE_COV_BUDGET_KB").ok()?;
-      let mut it = v.split(',').map(|s| s.trim().parse::<usize>());
-      match (it.next(), it.next(), it.next()) {
-        (Some(Ok(a)), Some(Ok(b)), Some(Ok(c))) => Some([a << 10, b << 10, c << 10]),
-        _ => None,
-      }
-    });
+    // Reading the environment is the one thing this crate does that core
+    // cannot, so no_std builds simply take the compiled-in budgets.
+    #[cfg(feature = "std")]
+    let ov = {
+      static OVERRIDE: std::sync::OnceLock<Option<[usize; 3]>> = std::sync::OnceLock::new();
+      OVERRIDE.get_or_init(|| {
+        let v = std::env::var("TLOTTIE_COV_BUDGET_KB").ok()?;
+        let mut it = v.split(',').map(|s| s.trim().parse::<usize>());
+        match (it.next(), it.next(), it.next()) {
+          (Some(Ok(a)), Some(Ok(b)), Some(Ok(c))) => Some([a << 10, b << 10, c << 10]),
+          _ => None,
+        }
+      })
+    };
+    #[cfg(not(feature = "std"))]
+    let ov = &None::<[usize; 3]>;
     let px = w.saturating_mul(h);
     self.shrink_entries = px > 160 * 160;
     if let Some([a, b, c]) = ov {

--- a/src/renderer/cpu/executor.rs
+++ b/src/renderer/cpu/executor.rs
@@ -3,6 +3,8 @@
 
 use super::mapped_surface::Surface;
 use crate::cells::CellRaster;
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 #[cfg(test)]
 use crate::error::Error;
 use crate::error::Result;
@@ -22,6 +24,7 @@ use crate::model::{Composition, DashElement, FillRule, FloatList, GradientKind, 
 use crate::raster::Rasterizer;
 use crate::renderer::frame::renderer::GRADIENT_LUT_SIZE;
 use crate::stroke::{stroke_polyline, StrokeSegment};
+use alloc::vec::Vec;
 
 /// Maximum group recursion while rendering (matches parse-side bound).
 const MAX_RENDER_DEPTH: usize = 40;
@@ -50,7 +53,7 @@ pub(crate) struct RenderScratch {
   /// from the stop list is pure, and stop values repeat across frames
   /// (static gradients: every frame; animated: on hold segments and loop
   /// repeats). Keyed by the exact input bits — no collision risk.
-  lut_cache: std::collections::HashMap<Vec<u32>, std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>>,
+  lut_cache: crate::compat::HashMap<Vec<u32>, alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>>,
   lut_key: Vec<u32>,
   /// Recycled contour point buffers: stroke pieces + fill snapshots draw
   /// from here and return after their paint executes (measured: 2,683
@@ -66,12 +69,12 @@ pub(crate) struct RenderScratch {
   /// Memoized per-layer staticness (keyed by the Layer's stable address
   /// inside the Arc'd Composition).
   #[cfg(test)]
-  static_flags: std::collections::HashMap<usize, bool>,
+  static_flags: crate::compat::HashMap<usize, bool>,
   /// Static-layer job lists: replay the exact fill calls (by coverage
   /// key) without walking/evaluating/flattening the shape tree at all —
   /// the per-frame cost rlottie avoids via its own static detection.
   #[cfg(test)]
-  jobs_cache: std::collections::HashMap<u128, Vec<ReplayJob>>,
+  jobs_cache: crate::compat::HashMap<u128, Vec<ReplayJob>>,
   /// Two-touch admission for jobs_cache: a replay key must be seen twice
   /// before recording (a static layer under an ANIMATED parent produces a
   /// fresh key every frame and must not flood the cache).
@@ -110,7 +113,7 @@ enum ReplayJob {
     key: u128,
     src_key: u128,
     rule: FillRule,
-    lut: std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
+    lut: alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
     map: GradientMap,
   },
 }
@@ -255,7 +258,7 @@ impl RenderScratch {
 
   /// Returns the LUT plus a 64-bit id of its exact inputs (used in the
   /// gradient source-plane cache key).
-  fn lut_for(&mut self, stops: &crate::model::FloatList, color_count: usize, opacity: f32) -> (std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>, u64) {
+  fn lut_for(&mut self, stops: &crate::model::FloatList, color_count: usize, opacity: f32) -> (alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>, u64) {
     self.lut_key.clear();
     self.lut_key.reserve(stops.0.len() + 2);
     self.lut_key.push(color_count as u32);
@@ -271,7 +274,7 @@ impl RenderScratch {
     if let Some(lut) = self.lut_cache.get(self.lut_key.as_slice()) {
       return (lut.clone(), id);
     }
-    let lut: std::sync::Arc<[u32; GRADIENT_LUT_SIZE]> = std::sync::Arc::new(build_gradient_lut(stops, color_count, opacity));
+    let lut: alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]> = alloc::sync::Arc::new(build_gradient_lut(stops, color_count, opacity));
     if self.lut_cache.len() >= LUT_CACHE_CAP {
       self.lut_cache.clear();
     }

--- a/src/renderer/cpu/gradient.rs
+++ b/src/renderer/cpu/gradient.rs
@@ -1,6 +1,7 @@
 //! Gradient lookup tables, coordinate maps, and compositing kernels.
 
 use super::*;
+use alloc::vec::Vec;
 
 /// Builds a premultiplied RGBA8 lookup table from independently interpolated
 /// Lottie color and opacity stops.

--- a/src/renderer/cpu/mapped_accumulator.rs
+++ b/src/renderer/cpu/mapped_accumulator.rs
@@ -1,5 +1,7 @@
 #![allow(unsafe_code)]
 
+use alloc::vec;
+use alloc::vec::Vec;
 use core::ops::Range;
 
 const MAP_THRESHOLD: usize = 1 << 20;

--- a/src/renderer/cpu/mapped_surface.rs
+++ b/src/renderer/cpu/mapped_surface.rs
@@ -1,5 +1,7 @@
 #![allow(unsafe_code)]
 
+use alloc::vec;
+use alloc::vec::Vec;
 use core::ops::{Deref, DerefMut};
 
 const MAP_THRESHOLD: usize = 1 << 20;

--- a/src/renderer/cpu/raster.rs
+++ b/src/renderer/cpu/raster.rs
@@ -5,8 +5,12 @@
 //! v0 keeps a full w×h f32 accumulation buffer. The cell/RLE engine with
 //! small-mask output replaces this in the rasterizer phase.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::geometry::Contour;
 use crate::model::FillRule;
+use alloc::vec;
+use alloc::vec::Vec;
 
 #[path = "mapped_accumulator.rs"]
 mod mapped_accumulator;

--- a/src/renderer/cpu/renderer.rs
+++ b/src/renderer/cpu/renderer.rs
@@ -1,6 +1,7 @@
 //! Public CPU renderer entry points.
 
 use crate::{Composition, Result};
+use alloc::vec::Vec;
 
 use super::executor::RenderScratch;
 
@@ -13,7 +14,7 @@ const STATIC_BITMAP_CACHE_BYTES: usize = 4 * 1024 * 1024;
 /// reusable raster buffers, mask planes, and gradient tables needed between
 /// frames. Rendering is synchronous and single-threaded by design.
 pub struct CPURenderer {
-  pub(super) comp: std::sync::Arc<Composition>,
+  pub(super) comp: alloc::sync::Arc<Composition>,
   pub(super) walker: crate::renderer::frame::FrameWalker,
   pub(super) state: RenderScratch,
   pub(super) bitmap: Option<core::ptr::NonNull<[u32]>>,
@@ -45,7 +46,7 @@ impl CPURenderer {
   /// Creates a CPU renderer owning its composition.
   pub fn new(comp: Composition) -> Self {
     Self {
-      comp: std::sync::Arc::new(comp),
+      comp: alloc::sync::Arc::new(comp),
       walker: Default::default(),
       state: RenderScratch::default(),
       bitmap: None,
@@ -65,7 +66,7 @@ impl CPURenderer {
   }
 
   /// Creates a CPU renderer over a shared composition.
-  pub fn from_shared(comp: std::sync::Arc<Composition>) -> Self {
+  pub fn from_shared(comp: alloc::sync::Arc<Composition>) -> Self {
     Self {
       comp,
       walker: Default::default(),
@@ -107,7 +108,7 @@ impl CPURenderer {
         }
       }
     }
-    let composition = std::sync::Arc::clone(&self.comp);
+    let composition = alloc::sync::Arc::clone(&self.comp);
     let mut walker = core::mem::take(&mut self.walker);
     let result = self.with_bitmap(pixels, width, height, options, |renderer| walker.render(&composition, frame, width, height, options, renderer));
     self.walker = walker;
@@ -172,7 +173,7 @@ impl CPURenderer {
     options.alpha_only = true;
     self.state.cov_cache.set_budget_for_canvas(width as usize, height as usize);
     self.state.cov_cache.frame_tick();
-    let composition = std::sync::Arc::clone(&self.comp);
+    let composition = alloc::sync::Arc::clone(&self.comp);
     let mut walker = core::mem::take(&mut self.walker);
     let mut backend = super::alpha_backend::Alpha8Renderer::new(target, width as usize, height as usize, options.antialias, options.clear, &mut self.state);
     let result = walker.render(&composition, frame, width, height, options, &mut backend);

--- a/src/renderer/cpu/simd.rs
+++ b/src/renderer/cpu/simd.rs
@@ -892,6 +892,8 @@ mod wasm128;
 #[path = "tests/simd.rs"]
 mod tests;
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 #[cfg(test)]
 #[path = "tests/alpha_simd.rs"]
 mod alpha_tests;

--- a/src/renderer/cpu/tests/alpha_simd.rs
+++ b/src/renderer/cpu/tests/alpha_simd.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec::Vec;
 
 struct Rng(u64);
 

--- a/src/renderer/cpu/tests/cells.rs
+++ b/src/renderer/cpu/tests/cells.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::math::Vec2;
 use crate::raster::Rasterizer;
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn plane_s(w: usize, h: usize, contours: &[Contour], rule: FillRule) -> Vec<u8> {
   let mut r = CellRaster::new(w, h);

--- a/src/renderer/cpu/tests/cov_cache.rs
+++ b/src/renderer/cpu/tests/cov_cache.rs
@@ -1,4 +1,6 @@
 use super::*;
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn entry(bytes: usize) -> CovEntry {
   CovEntry {

--- a/src/renderer/cpu/tests/gradient.rs
+++ b/src/renderer/cpu/tests/gradient.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec;
 
 #[test]
 fn opacity_stops_do_not_shift_color_interpolation() {

--- a/src/renderer/cpu/tests/mask_bounds.rs
+++ b/src/renderer/cpu/tests/mask_bounds.rs
@@ -12,6 +12,9 @@ use super::*;
 use crate::math::Vec2;
 use crate::model::{Composition, Mask, PathData, Transform};
 use crate::property::Property;
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn full_box(w: usize, h: usize) -> DirtyBox {
   DirtyBox { x0: 0, y0: 0, x1: w - 1, y1: h - 1 }

--- a/src/renderer/cpu/tests/pipeline_equivalence.rs
+++ b/src/renderer/cpu/tests/pipeline_equivalence.rs
@@ -1,6 +1,8 @@
 use crate::renderer::cpu::executor::{render_pooled, RenderScratch};
 use crate::renderer::frame::FrameRenderer;
 use crate::{Composition, Limits, RenderOptions};
+use alloc::format;
+use alloc::vec;
 
 #[test]
 fn single_mask_fast_path_matches_accumulator_formula() {

--- a/src/renderer/cpu/tests/raster.rs
+++ b/src/renderer/cpu/tests/raster.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::geometry::Contour;
 use crate::math::Vec2;
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn cov_sum(r: &mut Rasterizer, rule: FillRule) -> u64 {
   let mut total = 0u64;

--- a/src/renderer/cpu/tests/simd.rs
+++ b/src/renderer/cpu/tests/simd.rs
@@ -1,4 +1,6 @@
 use super::*;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// Deterministic xorshift — no dev-dependency needed.
 struct Rng(u64);

--- a/src/renderer/frame/evaluator.rs
+++ b/src/renderer/frame/evaluator.rs
@@ -1,6 +1,7 @@
 //! Shape evaluation shared by the frame walker and CPU test oracle.
 
 use super::*;
+use alloc::vec::Vec;
 
 pub(crate) struct ShapeWalker<'a> {
   pub(crate) scratch: &'a mut RenderScratch,
@@ -29,13 +30,13 @@ enum PendingPaint {
   },
   Gradient {
     rule: FillRule,
-    lut: std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
+    lut: alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
     lut_id: u64,
     map: GradientMap,
   },
   Stroke {
     color: Option<Color>,
-    lut: Option<(std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>, u64, GradientMap)>,
+    lut: Option<(alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>, u64, GradientMap)>,
     opacity: f32,
     hw: f32,
     cap: crate::stroke::Cap,
@@ -69,7 +70,7 @@ pub(crate) enum DrawJob {
     contours: Vec<Contour>,
     borrowed: Option<usize>,
     rule: FillRule,
-    lut: std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
+    lut: alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
     map: GradientMap,
   },
 }

--- a/src/renderer/frame/geometry.rs
+++ b/src/renderer/frame/geometry.rs
@@ -4,8 +4,12 @@
 //! polygon length in device space; the adaptive/scale-aware flattener comes
 //! with the quality/perf phases.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::math::{Mat2x3, Vec2};
 use crate::model::PathData;
+use alloc::vec;
+use alloc::vec::Vec;
 
 /// One closed (or open) contour as a device-space polyline.
 #[derive(Debug, Clone, Default)]

--- a/src/renderer/frame/renderer.rs
+++ b/src/renderer/frame/renderer.rs
@@ -58,7 +58,7 @@ pub enum GradientKind {
 #[derive(Clone, Debug)]
 pub struct GradientPaint {
   pub rule: Rule,
-  pub lut: std::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
+  pub lut: alloc::sync::Arc<[u32; GRADIENT_LUT_SIZE]>,
   pub transform: GradientTransform,
   pub kind: GradientKind,
   pub(crate) source_key: u128,

--- a/src/renderer/frame/stroke.rs
+++ b/src/renderer/frame/stroke.rs
@@ -4,8 +4,11 @@
 //! with opposite winding. Input cleanup lives here so every renderer sees
 //! identical stroke geometry.
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::geometry::Contour;
 use crate::math::Vec2;
+use alloc::vec::Vec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Cap {

--- a/src/renderer/frame/tests/geometry.rs
+++ b/src/renderer/frame/tests/geometry.rs
@@ -1,4 +1,6 @@
 use super::*;
+use alloc::vec;
+use alloc::vec::Vec;
 
 #[test]
 fn rounds_each_corner_of_a_closed_square() {

--- a/src/renderer/frame/tests/stroke.rs
+++ b/src/renderer/frame/tests/stroke.rs
@@ -1,4 +1,6 @@
 use super::*;
+use alloc::vec;
+use alloc::vec::Vec;
 
 fn stroke(pts: &[(f32, f32)], closed: bool, hw: f32, cap: Cap, join: Join, ml: f32) -> Vec<Contour> {
   let v: Vec<Vec2> = pts.iter().map(|&(x, y)| Vec2::new(x, y)).collect();

--- a/src/renderer/frame/tests/walker.rs
+++ b/src/renderer/frame/tests/walker.rs
@@ -1,4 +1,5 @@
 use super::*;
+use alloc::vec::Vec;
 
 #[derive(Default)]
 struct Counter {

--- a/src/renderer/frame/walker.rs
+++ b/src/renderer/frame/walker.rs
@@ -6,12 +6,16 @@
 
 #![allow(missing_docs)]
 
+#[cfg(not(feature = "std"))]
+use crate::compat::FloatExt as _;
 use crate::error::{Error, Result};
 use crate::geometry::{clip_contour, clip_to_quad, flatten_path, rect_contour, Contour};
 use crate::limits::Limits;
 use crate::math::{Color, Mat2x3, Vec2};
 use crate::model::{shapes_have_multiple_visible_paints, shapes_static, Composition, FillRule, Layer, LayerKind};
 use crate::renderer::cpu::executor::{layer_transform_at, opacity_byte, parent_chain_matrix, ClipQuad, DrawJob, GradientMapKind, PendingJob, RenderCtx, RenderScratch, ShapeWalker, MAX_PRECOMP_DEPTH};
+use alloc::vec;
+use alloc::vec::Vec;
 
 use super::renderer::*;
 
@@ -176,10 +180,10 @@ struct CachedLayerJobs {
 
 #[derive(Default)]
 struct StaticJobCache {
-  entries: std::collections::HashMap<u128, CachedLayerJobs>,
-  seen: std::collections::HashSet<u128>,
-  rejected: std::collections::HashSet<u128>,
-  static_flags: std::collections::HashMap<(usize, usize), bool>,
+  entries: crate::compat::HashMap<u128, CachedLayerJobs>,
+  seen: crate::compat::HashSet<u128>,
+  rejected: crate::compat::HashSet<u128>,
+  static_flags: crate::compat::HashMap<(usize, usize), bool>,
   bytes: usize,
   #[cfg(test)]
   hits: usize,
@@ -269,7 +273,7 @@ fn static_jobs_bytes(context: &StaticContext, jobs: &Vec<CachedJob>) -> usize {
         .saturating_add(contour.anchors.capacity().saturating_mul(core::mem::size_of::<bool>()));
     }
     if let CachedPaint::Gradient(paint) = &job.paint {
-      let ptr = std::sync::Arc::as_ptr(&paint.lut);
+      let ptr = alloc::sync::Arc::as_ptr(&paint.lut);
       if !gradient_luts.contains(&ptr) {
         gradient_luts.push(ptr);
         bytes = bytes.saturating_add(core::mem::size_of::<[u32; GRADIENT_LUT_SIZE]>());


### PR DESCRIPTION
The motivation is the **toolchain**, not size.

The `*-uwp-windows-msvc` targets are tier 3, so building for a Windows app container with `std` needs a nightly toolchain and `-Z build-std`. The ordinary `x86_64-pc-windows-msvc` std cannot be used instead: `std::sys::stdio::windows::write` pulls in `NtWriteFile` and `RtlNtStatusToDosError`, which do not resolve against `WindowsApp.lib` and fail the link outright.

Without `std` both problems disappear at once. The crate builds **on stable for the tier-1 target** and links into an app container against `WindowsApp.lib` alone, importing nothing beyond the allocator, libm and CRT startup:

```
api-ms-win-crt-heap-l1-1-0.dll
api-ms-win-crt-math-l1-1-0.dll
api-ms-win-crt-runtime-l1-1-0.dll
KERNEL32.dll        (InitializeSListHead, QueryPerformanceCounter, ... - CRT startup)
VCRUNTIME140.dll
```

Shipping a nightly toolchain plus a tier-3 target in a production build chain is the liability this retires.

### Shaped as an addition, not a restructure

`std` is a **default feature**, so every existing consumer is unaffected and nothing about the default build changes. `--no-default-features` opts out.

Almost the whole diff is mechanical: `alloc` paths are valid in `std` builds too, so those imports are unconditional and both configurations read the same — no `cfg` noise scattered through the renderer.

Only three things genuinely differ, and they are all in one new `compat` module:

- **`alloc` has no hash map.** hashbrown is the implementation `std::collections::HashMap` already wraps, so the caches keyed by it behave *and perform* identically. It is an optional dependency reachable only from this path; default builds stay dependency-free.
- **Float methods that lower to libm calls** are provided by a `FloatExt` trait over the C runtime's own symbols, so no Rust libm reimplementation is pulled in. In `std` builds the trait is not compiled at all and the inherent methods are used, so behaviour is bit-identical rather than merely equivalent.
- **`std::error::Error` is not implemented**, `core` having no such trait. `Debug`, `Display` and the enum itself are unchanged.

The `TLOTTIE_COV_BUDGET_KB` dev hook is std-only; `no_std` builds take the compiled-in budgets.

A staticlib handed to a C host also needs a global allocator and a panic handler, which no C++ caller can define. Those are provided **only** for `no_std` + `c-api` builds: the allocator forwards to the host CRT (hand-aligning anything stricter than `malloc` guarantees), and panics abort without formatting a message, which is also what keeps `core::fmt`'s machinery out. `no_std` requires `panic=abort`, hence the `release-nostd` profile.

### Verification

Every one of the **16,393 Telegram fixtures** rendered through a std-linked and a no_std-linked build of the C API, three frames each, hashed and compared:

```
std lines: 16393  nostd lines: 16393
IDENTICAL across all 16393 fixtures
```

So the libm shim is bit-exact against std's inherent methods, not approximately right. The std build's 103 tests still pass and its warning set is unchanged.

### Size

Measured on an app-container DLL exposing the same C API surface:

| build | size |
|---|---|
| std + unwind (today) | 589.5 KB |
| std + `panic=abort` | 456.5 KB |
| no_std + `panic=abort` | 398.0 KB |

Worth being straight about the split: **most of that is `panic=abort`, which std builds can take on their own** — `no_std` adds a further 58.5 KB on top of the toolchain benefit. Size is a side effect here, not the argument.

### Building it

```bash
cargo rustc --profile release-nostd --no-default-features \
  --features cpu,c-api,hashbrown --lib --crate-type staticlib
```

Stable toolchain, tier-1 target, no `build-std`. Omitting `hashbrown` fails with a `compile_error!` explaining why rather than a wall of resolution errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)