### PR TITLE
Capture static jobs at the real matrix, not a canonical origin

### DIFF
--- a/src/renderer/frame/tests/walker.rs
+++ b/src/renderer/frame/tests/walker.rs
@@ -150,7 +150,7 @@ fn static_job_cache_invalidates_on_render_context_change() {
 }
 
 #[test]
-fn static_jobs_replay_fractional_translation_exactly() {
+fn translating_static_layer_matches_a_fresh_walker() {
   let json = br#"{"fr":30,"ip":0,"op":20,"w":100,"h":100,"layers":[
     {"ty":4,"ind":1,"ip":0,"op":20,"st":0,
      "ks":{"o":{"a":0,"k":100},"p":{"a":1,"k":[{"t":0,"s":[20,30],"e":[60,55]},{"t":10,"s":[60,55]}]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"r":{"a":0,"k":0}},
@@ -160,9 +160,11 @@ fn static_jobs_replay_fractional_translation_exactly() {
        {"ty":"tr","p":{"a":0,"k":[0,0]},"a":{"a":0,"k":[0,0]},"s":{"a":0,"k":[100,100]},"r":{"a":0,"k":0},"o":{"a":0,"k":100}}
      ]}]}
   ]}"#;
+  // A reused walker must render every frame exactly as a fresh one would.
+  // The static-job cache is an optimisation, never a change in output.
   let comp = Composition::parse(json, &Limits::default()).unwrap();
   let mut cached = FrameWalker::default();
-  for frame in [0.0, 1.0, 2.5] {
+  for frame in [0.0, 1.0, 2.5, 3.0, 4.0, 7.5, 10.0, 12.0] {
     let mut actual = Trace::default();
     cached.render(&comp, frame, 100, 100, crate::RenderOptions::default(), &mut actual).unwrap();
 
@@ -170,5 +172,9 @@ fn static_jobs_replay_fractional_translation_exactly() {
     FrameWalker::default().render(&comp, frame, 100, 100, crate::RenderOptions::default(), &mut expected).unwrap();
     assert_eq!(actual, expected, "frame {frame}");
   }
-  assert_eq!(cached.static_jobs.hits, 1);
+  // Deliberately no hit-count assertion: a layer that only translates used
+  // to be captured at a canonical origin so the translation became a replay
+  // parameter, which is what this asserted. That capture had to run
+  // unbounded, and the unclipped geometry it produced dropped scanlines on
+  // the recording frame. The equivalence above is the property that matters.
 }

--- a/src/renderer/frame/walker.rs
+++ b/src/renderer/frame/walker.rs
@@ -536,17 +536,19 @@ impl RenderCtx<'_> {
         // contours costs more than the saved walk. Keep the exact-context
         // path there; this cache targets the small-icon regime where the
         // retained-state gap was measured.
-        let translation_parametric = clip.is_empty() && layer_static && width.max(height) <= 320;
-        let mut canonical_m = m;
-        if translation_parametric {
-          canonical_m.tx = 0.0;
-          canonical_m.ty = 0.0;
-        }
-        let static_context = layer_static.then(|| StaticContext::new(self.comp, layer, canonical_m, content_opacity, color_override, width, height, antialias, self.curve_tolerance, clip));
-        let replay_translation = if translation_parametric { (m.tx, m.ty) } else { (0.0, 0.0) };
+        // Capture always runs at the real device matrix, bounded.
+        //
+        // Capturing at a canonical origin instead, so that a pure
+        // translation became a replay parameter, forced the recording pass
+        // to run `unbounded`: clipping cannot be baked in when the position
+        // is meant to vary. That handed the rasteriser unclipped geometry,
+        // which no other frame ever produces, and dropped scanlines on the
+        // recording frame — a visible hole in 31 of 260 sampled Telegram
+        // fixtures. It also measured flat, so the reuse was not worth it.
+        let static_context = layer_static.then(|| StaticContext::new(self.comp, layer, m, content_opacity, color_override, width, height, antialias, self.curve_tolerance, clip));
         let signature = static_context.as_ref().map(StaticContext::signature);
         if let (Some(context), Some(signature)) = (static_context.as_ref(), signature) {
-          if static_jobs.replay(signature, context, replay_translation.0, replay_translation.1, renderer) {
+          if static_jobs.replay(signature, context, 0.0, 0.0, renderer) {
             return Ok(());
           }
         }
@@ -560,9 +562,9 @@ impl RenderCtx<'_> {
           height,
           antialias,
           color_override,
-          unbounded: record && translation_parametric,
+          unbounded: false,
         };
-        let (arena, pending) = walker.walk_shapes(&layer.shapes, if record { canonical_m } else { m }, content_opacity, 0)?;
+        let (arena, pending) = walker.walk_shapes(&layer.shapes, m, content_opacity, 0)?;
         let mut recorded = record.then(|| Vec::with_capacity(pending.len()));
         walker.collect_shape_jobs(&arena, &pending, renderer, recorded.as_mut(), !record);
         for (contour, _) in arena {
@@ -570,7 +572,7 @@ impl RenderCtx<'_> {
         }
         if let (Some(context), Some(signature), Some(jobs)) = (static_context, signature, recorded) {
           for job in &jobs {
-            job.replay(replay_translation.0, replay_translation.1, renderer);
+            job.replay(0.0, 0.0, renderer);
           }
           static_jobs.insert(signature, context, jobs);
         }


### PR DESCRIPTION
Small stickers render with holes in them — a white band punched through the artwork, where the background shows through. Reported against a real Telegram sticker; reproduces on `dev`, on x86_64 and on Android.

### Cause

A layer whose shapes are all static gets its draw jobs captured once and replayed on later frames. To let a layer that *merely translates* reuse that capture, the recording pass ran at a canonical origin (tx/ty zeroed) and applied the translation at replay time.

That capture has to run **`unbounded`** — clipping cannot be baked in when the position is meant to vary. So the recording pass hands the rasteriser unclipped geometry, which no ordinary frame ever produces, and scanlines get dropped on whichever frame happens to record.

Two things made this hard to spot:

- it is gated on `width.max(height) <= 320`, so the same animation is clean at higher resolutions and only small renders are wrong;
- it is the **recording** frame that is wrong, not the replayed ones. Disabling `StaticJobCache::replay` alone reduces how many frames differ but leaves the hole exactly as it was, which sends you looking in the wrong place.

It is not a transient glitch either — on the reporter's file the hole is present on **92 of 180 frames**.

### Fix

Capture always runs at the real device matrix, bounded. Layers whose matrix is unchanged between frames still hit the cache; only the translation-reuse case is given up.

That case measured flat, so there is nothing being traded away — 260 corpus fixtures, best-of-run:

| size | before | after | delta |
|---|---|---|---|
| 64 | 1119.8 ms | 1114.2 ms | -0.5% |
| 128 | 1730.8 ms | 1741.5 ms | +0.6% |
| 320 | 3651.8 ms | 3622.0 ms | -0.8% |

### How it was found, and the check I would suggest keeping

By rendering frames **sequentially on one renderer** and comparing against a **fresh renderer per frame**. A player drives one long-lived instance, so any divergence between those two is user-visible by definition — and the caches are documented as bit-exact optimisations, so there should be none.

That check is worth having in CI: it is the only thing that catches this class of bug, and a per-frame-instance corpus sweep is structurally blind to all of it.

```
                        files diverging   frames   worst frame
before (260 fixtures)         31            326      1284 px
after  (1000 fixtures)         0              0          0 px
```

`cargo test` is green (103 lib tests). The walker test that asserted the fractional-translation cache hit now asserts the property that actually matters instead: a reused walker renders every frame exactly as a fresh one would, over more frames than before.

Happy to share the harness (a small C++ driver over the C API that renders persistent-vs-fresh and diffs) if it would be useful in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)