### PR TITLE
Fix NEON alpha matting failing to compile

### DIFF
--- a/src/renderer/cpu/simd/neon.rs
+++ b/src/renderer/cpu/simd/neon.rs
@@ -443,7 +443,7 @@ pub(super) fn apply_matte_alpha_neon(dst: &mut [u32], src: &[u32], source_opacit
       vmovn_u16(div255_round(vmulq_u16(vmovl_u8(d4.0), f))),
       vmovn_u16(div255_round(vmulq_u16(vmovl_u8(d4.1), f))),
       vmovn_u16(div255_round(vmulq_u16(vmovl_u8(d4.2), f))),
-      vmovn_u16(div255_round(vmovl_u8(d4.3), f)),
+      vmovn_u16(div255_round(vmulq_u16(vmovl_u8(d4.3), f))),
     );
     // SAFETY: same 32-byte span as the load above.
     #[allow(unsafe_code)]


### PR DESCRIPTION
`dev` does not build for aarch64 right now:

```
error[E0061]: this function takes 1 argument but 2 arguments were supplied
   --> src/renderer/cpu/simd/neon.rs:446:17
    |
446 |       vmovn_u16(div255_round(vmovl_u8(d4.3), f)),
```

The alpha lane in `alpha_matte_neon` lost its multiply. `div255_round` takes one argument, and the three sibling lanes immediately above it all read `div255_round(vmulq_u16(vmovl_u8(d4.N), f))`.

`alpha_matte_sse2` confirms the intent — it scales every lane, alpha included, by the matte factor before the rounded `/255`:

```rust
let l = div255_round(_mm_mullo_epi16(lo(d), fl));
```

One line. `cargo build --target aarch64-pc-windows-msvc` goes from failing to clean, and the x86_64 suite is unaffected.

Worth noting the gap this slipped through: NEON is only compiled on aarch64, so an x86_64-only CI run cannot catch it. A `cargo check --target aarch64-unknown-linux-gnu` (or any aarch64 target — no runner needed, it only has to typecheck) would have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)