### PR TITLE
Fix opaque fill kernels reading past their coverage chunk

### DIFF
--- a/src/renderer/cpu/simd/avx2.rs
+++ b/src/renderer/cpu/simd/avx2.rs
@@ -21,9 +21,9 @@
 
 use core::arch::x86_64::{
   _CMP_GE_OQ, _CMP_LT_OQ, _CMP_UNORD_Q, __m256, __m256i, _mm256_add_epi16, _mm256_add_ps, _mm256_and_ps, _mm256_and_si256, _mm256_andnot_ps, _mm256_andnot_si256,
-  _mm256_castps_si256, _mm256_castsi128_si256, _mm256_castsi256_ps, _mm256_castsi256_si128, _mm256_cmp_ps, _mm256_cmpeq_epi16, _mm256_cmpeq_epi8, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvtepu8_epi16, _mm256_cvttps_epi32,
+  _mm256_castps_si256, _mm256_castsi128_si256, _mm256_castsi256_ps, _mm256_castsi256_si128, _mm256_cmp_ps, _mm256_cmpeq_epi16, _mm256_cmpeq_epi32, _mm256_cmpgt_epi32, _mm256_cvtepu8_epi16, _mm256_cvttps_epi32,
   _mm256_extracti128_si256, _mm256_inserti128_si256, _mm256_loadu_si256, _mm256_mask_i32gather_epi32, _mm256_max_epi16, _mm256_max_ps, _mm256_min_epi16, _mm256_min_ps, _mm256_movemask_epi8,
-  _mm256_mul_ps, _mm256_mullo_epi16, _mm256_or_ps, _mm256_or_si256, _mm256_packus_epi16, _mm256_permute4x64_epi64, _mm256_set1_epi8, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi16,
+  _mm256_mul_ps, _mm256_mullo_epi16, _mm256_or_ps, _mm256_or_si256, _mm256_packus_epi16, _mm256_permute4x64_epi64, _mm256_set1_epi16, _mm256_set1_epi32, _mm256_set1_ps, _mm256_setr_epi16,
   _mm256_setr_ps, _mm256_setzero_ps, _mm256_setzero_si256, _mm256_shufflehi_epi16, _mm256_shufflelo_epi16, _mm256_sqrt_ps, _mm256_srli_epi16, _mm256_storeu_si256, _mm256_sub_epi16,
   _mm256_sub_ps, _mm_cvtsi32_si128, _mm_unpacklo_epi8, _mm_unpacklo_epi16,
 };
@@ -508,15 +508,11 @@ pub(super) fn focal_lut_over_avx2(dst: &mut [u32], lut: &[u32], g0x: f32, g0y: f
 pub(super) fn fill_span_opaque_avx2(dst: &mut [u32], cov: &[u8], color: u32) {
   let colorv = _mm256_set1_epi32(color as i32);
   for (dpx, cpx) in dst.chunks_exact_mut(8).zip(cov.chunks_exact(8)) {
-    // SAFETY: chunks_exact(8) yields exactly 8 u32 / 8 u8 slices; the
-    // stores/loads below use exactly those sizes.
-    #[allow(unsafe_code)]
-    let all255 = unsafe {
-      _mm256_movemask_epi8(_mm256_cmpeq_epi8(
-        _mm256_loadu_si256(cpx.as_ptr().cast()),
-        _mm256_set1_epi8(-1),
-      ))
-    } == !0;
+    // The coverage test reads the chunk as one u64: exactly the 8 bytes this
+    // iteration owns. A 256-bit load takes in the next 24 as well, which runs
+    // past the slice on the final chunk, and demands all 32 be 255 before the
+    // fast path can fire.
+    let all255 = u64::from_le_bytes(cpx.try_into().unwrap_or([0; 8])) == u64::MAX;
     if all255 {
       #[allow(unsafe_code)]
       unsafe {

--- a/src/renderer/cpu/simd/avx512.rs
+++ b/src/renderer/cpu/simd/avx512.rs
@@ -20,7 +20,7 @@
 
 use core::arch::x86_64::{
   _CMP_GE_OQ, _CMP_LT_OQ, _CMP_UNORD_Q, __m512, __m512i, _mm256_setr_epi16, _mm512_add_epi16, _mm512_add_ps, _mm512_and_ps, _mm512_castps_si512, _mm512_castsi128_si512,
-  _mm512_castsi256_si512, _mm512_castsi512_ps, _mm512_castsi512_si256, _mm512_cmpeq_epi16_mask, _mm512_cmpeq_epi8_mask, _mm512_cmpeq_epi32_mask, _mm512_cmp_ps_mask, _mm512_cvtepu8_epi16, _mm512_cvttps_epi32, _mm512_cvtusepi16_epi8,
+  _mm512_castsi256_si512, _mm512_castsi512_ps, _mm512_castsi512_si256, _mm512_cmpeq_epi16_mask, _mm512_cmpeq_epi32_mask, _mm512_cmp_ps_mask, _mm512_cvtepu8_epi16, _mm512_cvttps_epi32, _mm512_cvtusepi16_epi8,
   _mm512_extracti64x4_epi64, _mm512_inserti32x4, _mm512_inserti64x4, _mm512_loadu_si512, _mm512_mask_i32gather_epi32, _mm512_mask_mov_epi32, _mm512_max_epi16, _mm512_max_ps,
   _mm512_min_epi16, _mm512_min_ps, _mm512_mul_ps, _mm512_mullo_epi16, _mm512_set1_epi16, _mm512_set1_epi32, _mm512_set1_ps, _mm512_setr_ps, _mm512_setzero_ps, _mm512_setzero_si512,
   _mm512_shufflehi_epi16, _mm512_shufflelo_epi16, _mm512_sqrt_ps, _mm512_srli_epi16, _mm512_storeu_si512, _mm512_sub_epi16, _mm512_sub_ps, _mm_cvtsi32_si128, _mm_unpacklo_epi8,
@@ -521,15 +521,10 @@ pub(super) fn focal_lut_over_avx512(dst: &mut [u32], lut: &[u32], g0x: f32, g0y:
 pub(super) fn fill_span_opaque_avx512(dst: &mut [u32], cov: &[u8], color: u32) {
   let colorv = _mm512_set1_epi32(color as i32);
   for (dpx, cpx) in dst.chunks_exact_mut(16).zip(cov.chunks_exact(16)) {
-    // SAFETY: chunks_exact(16) yields exactly 16 u32 / 16 u8 slices; the
-    // load and mask compare below use exactly those sizes.
-    #[allow(unsafe_code)]
-    let all255 = unsafe {
-      _mm512_cmpeq_epi8_mask(
-        _mm512_loadu_si512(cpx.as_ptr().cast()),
-        _mm512_set1_epi32(-1),
-      )
-    } == u64::MAX;
+    // Reads the chunk as one u128: exactly the 16 bytes this iteration owns.
+    // A 512-bit load pulls in the next 48 as well, running past the slice on
+    // the final chunk and demanding all 64 be 255.
+    let all255 = u128::from_le_bytes(cpx.try_into().unwrap_or([0; 16])) == u128::MAX;
     if all255 {
       #[allow(unsafe_code)]
       unsafe {


### PR DESCRIPTION
`fill_span_opaque_avx2` iterates `cov.chunks_exact(8)` but tests coverage with a 256-bit load:

```rust
for (dpx, cpx) in dst.chunks_exact_mut(8).zip(cov.chunks_exact(8)) {
    // SAFETY: chunks_exact(8) yields exactly 8 u32 / 8 u8 slices; the
    // stores/loads below use exactly those sizes.
    let all255 = _mm256_movemask_epi8(_mm256_cmpeq_epi8(
        _mm256_loadu_si256(cpx.as_ptr().cast()), _mm256_set1_epi8(-1))) == !0;
```

`cpx` is 8 bytes; the load reads 32. On the final chunk that is a read past the end of the slice. `fill_span_opaque_avx512` has the same shape — 16-byte chunk, 512-bit load, 48 bytes over.

There is a second, quieter consequence: comparing the whole register means the fast path only fires when the *following* 24 (or 48) coverage bytes happen to be opaque as well, so the wide store was being taken far less often than intended. The `else` branch does the correct scalar fill, so pixels were never wrong — this is UB plus a missed optimisation, not a rendering bug.

Testing the chunk as a single `u64` / `u128` reads exactly what the iteration owns and restores the intended condition:

```rust
let all255 = u64::from_le_bytes(cpx.try_into().unwrap_or([0; 8])) == u64::MAX;
```

Verified on an AVX2 machine: output identical across 3000 fixtures at 512px. And because the fast path now fires as often as it should, it is slightly quicker — **-1.2% at 320px, -0.3% at 720px** over 260 corpus fixtures.

Found while implementing an SSE2 counterpart for these kernels. That turned out to be a regression and I am not proposing it: the existing scalar path finds arbitrarily long opaque runs and does one `run.fill(color)`, which is a memset LLVM already vectorises, and 128-bit chunking loses more to the per-chunk test than it gains. Measured +3.4% to +5.4% at 320px. AVX2 and AVX-512 are wide enough for the trade to pay; SSE2 is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)