### PR TITLE
fix dash guards measuring path length by chords at frame 0 only

### DIFF
--- a/src/composition/parse.rs
+++ b/src/composition/parse.rs
@@ -828,7 +828,8 @@ fn cubic_span(a: Vec2, out_a: Vec2, in_b: Vec2, b: Vec2) -> f32 {
 /// `(longest segment, total length)` of one path keyframe.
 fn path_data_span(data: &PathData) -> (f32, f32) {
   let count = data.vertices.len();
-  if count < 2 {
+  // A closed single-vertex path still has a cubic back to itself.
+  if count == 0 {
     return (0.0, 0.0);
   }
   let at = |list: &[Vec2], i: usize| list.get(i).copied().unwrap_or(Vec2::new(0.0, 0.0));

--- a/src/composition/parse.rs
+++ b/src/composition/parse.rs
@@ -800,23 +800,23 @@ fn path_keyframe_values(property: &Property<PathData>) -> Vec<&PathData> {
   }
 }
 
-/// Arclength estimate for one cubic, in the Chebyshev metric the dash
-/// limits use: the mean of the chord and the control polygon (Gravesen,
-/// "Adaptive subdivision and the length and energy of Bezier curves",
-/// Comput. Geom. 8 (1997)). With zero tangents polygon == chord, so
-/// straight paths score exactly what they scored before.
+/// Upper bound on one cubic's arclength, in the Chebyshev metric the dash
+/// limits use: the control polygon. chord <= L <= polygon holds for any
+/// bezier (Gravesen, "Adaptive subdivision and the length and energy of
+/// Bezier curves", Comput. Geom. 8 (1997)); with zero tangents polygon ==
+/// chord, so straight paths score exactly what they scored before.
 ///
-/// The chord alone is useless as a bound: a segment with both endpoints on
-/// one coordinate has a zero chord and a zero bbox while its tangents still
-/// pull the real curve ~294k px out and back (bbox.tgs), which a 0.005 dash
-/// period then slices into ~1.3e9 pieces.
+/// A bound, not an estimate, on purpose: the chord measures zero for a
+/// segment with both endpoints on one coordinate while its tangents still
+/// pull the real curve ~294k px out and back (bbox.tgs), which a 0.005
+/// dash period then slices into ~1.3e9 pieces. That curve also has a cusp
+/// at t=0.5, exactly where the cheaper arclength estimates lose their
+/// guarantees, so the guard rests on the inequality instead.
 fn cubic_span(a: Vec2, out_a: Vec2, in_b: Vec2, b: Vec2) -> f32 {
   let hop = |px: f32, py: f32, qx: f32, qy: f32| (qx - px).abs().max((qy - py).abs());
   let (c0x, c0y) = (a.x + out_a.x, a.y + out_a.y);
   let (c1x, c1y) = (b.x + in_b.x, b.y + in_b.y);
-  let chord = hop(a.x, a.y, b.x, b.y);
-  let polygon = hop(a.x, a.y, c0x, c0y) + hop(c0x, c0y, c1x, c1y) + hop(c1x, c1y, b.x, b.y);
-  let span = 0.5 * (chord + polygon);
+  let span = hop(a.x, a.y, c0x, c0y) + hop(c0x, c0y, c1x, c1y) + hop(c1x, c1y, b.x, b.y);
   //NOTE: a NaN would slip through the max()/sum() comparisons downstream
   if span.is_finite() {
     span

--- a/src/composition/parse.rs
+++ b/src/composition/parse.rs
@@ -605,8 +605,9 @@ fn parse_shape_list(c: &mut Cursor<'_>, limits: &Limits, depth: usize, count: &m
             return Err(Error::LimitExceeded(Limit::GradientStrokesPerGroup));
           }
         }
-        max_dashed_source_segment = max_dashed_source_segment.max(max_path_segment_span(&s));
-        dashed_source_len += path_segment_span_sum(&s);
+        let (segment_span, path_span) = path_span_metrics(&s);
+        max_dashed_source_segment = max_dashed_source_segment.max(segment_span);
+        dashed_source_len += path_span;
         if is_geometry_source(&s) {
           source_items += 1;
         }
@@ -781,34 +782,82 @@ fn property_max_abs_f32(property: &Property<f32>) -> Option<f32> {
   }
 }
 
-fn max_path_segment_span(shape: &Shape) -> f32 {
-  let Shape::Path(path) = shape else {
-    return 0.0;
-  };
-  let data = path.path.eval(0.0);
-  data
-    .vertices
-    .windows(2)
-    .map(|w| match w {
-      [a, b] => (b.x - a.x).abs().max((b.y - a.y).abs()),
-      _ => 0.0,
-    })
-    .fold(0.0, f32::max)
+/// Every `PathData` a path property can evaluate to. Interpolated frames
+/// stay within their two keyframes, so the authored ones bound the timeline.
+fn path_keyframe_values(property: &Property<PathData>) -> Vec<&PathData> {
+  match property {
+    Property::Static(data) => vec![data],
+    Property::Animated(timeline) => {
+      let mut values = Vec::with_capacity(2 * (timeline.rest.len() + 1));
+      values.push(&timeline.first.value);
+      values.extend(timeline.first.end.as_ref());
+      for keyframe in &timeline.rest {
+        values.push(&keyframe.value);
+        values.extend(keyframe.end.as_ref());
+      }
+      values
+    }
+  }
 }
 
-fn path_segment_span_sum(shape: &Shape) -> f32 {
+/// Arclength estimate for one cubic, in the Chebyshev metric the dash
+/// limits use: the mean of the chord and the control polygon (Gravesen,
+/// "Adaptive subdivision and the length and energy of Bezier curves",
+/// Comput. Geom. 8 (1997)). With zero tangents polygon == chord, so
+/// straight paths score exactly what they scored before.
+///
+/// The chord alone is useless as a bound: a segment with both endpoints on
+/// one coordinate has a zero chord and a zero bbox while its tangents still
+/// pull the real curve ~294k px out and back (bbox.tgs), which a 0.005 dash
+/// period then slices into ~1.3e9 pieces.
+fn cubic_span(a: Vec2, out_a: Vec2, in_b: Vec2, b: Vec2) -> f32 {
+  let hop = |px: f32, py: f32, qx: f32, qy: f32| (qx - px).abs().max((qy - py).abs());
+  let (c0x, c0y) = (a.x + out_a.x, a.y + out_a.y);
+  let (c1x, c1y) = (b.x + in_b.x, b.y + in_b.y);
+  let chord = hop(a.x, a.y, b.x, b.y);
+  let polygon = hop(a.x, a.y, c0x, c0y) + hop(c0x, c0y, c1x, c1y) + hop(c1x, c1y, b.x, b.y);
+  let span = 0.5 * (chord + polygon);
+  //NOTE: a NaN would slip through the max()/sum() comparisons downstream
+  if span.is_finite() {
+    span
+  } else {
+    f32::MAX
+  }
+}
+
+/// `(longest segment, total length)` of one path keyframe.
+fn path_data_span(data: &PathData) -> (f32, f32) {
+  let count = data.vertices.len();
+  if count < 2 {
+    return (0.0, 0.0);
+  }
+  let at = |list: &[Vec2], i: usize| list.get(i).copied().unwrap_or(Vec2::new(0.0, 0.0));
+  let last = if data.closed { count } else { count - 1 };
+  let mut max = 0.0f32;
+  let mut sum = 0.0f32;
+  for i in 0..last {
+    let j = if i + 1 == count { 0 } else { i + 1 };
+    let span = cubic_span(at(&data.vertices, i), at(&data.out_tangents, i), at(&data.in_tangents, j), at(&data.vertices, j));
+    max = max.max(span);
+    sum += span;
+  }
+  (max, sum)
+}
+
+/// `(longest segment, total length)` over the path timeline. Totals are
+/// maxed across keyframes, not summed: the dasher only sees one frame.
+fn path_span_metrics(shape: &Shape) -> (f32, f32) {
   let Shape::Path(path) = shape else {
-    return 0.0;
+    return (0.0, 0.0);
   };
-  let data = path.path.eval(0.0);
-  data
-    .vertices
-    .windows(2)
-    .map(|w| match w {
-      [a, b] => (b.x - a.x).abs().max((b.y - a.y).abs()),
-      _ => 0.0,
-    })
-    .sum()
+  let mut max = 0.0f32;
+  let mut total = 0.0f32;
+  for data in path_keyframe_values(&path.path) {
+    let (segment_max, segment_sum) = path_data_span(data);
+    max = max.max(segment_max);
+    total = total.max(segment_sum);
+  }
+  (max, total)
 }
 
 fn parse_shape_item(c: &mut Cursor<'_>, limits: &Limits, depth: usize, count: &mut ShapeCounts) -> Result<ParsedItem> {

--- a/src/tests/dos.rs
+++ b/src/tests/dos.rs
@@ -2436,3 +2436,26 @@ fn duplicate_scalar_property_k_keyframes_stay_bounded() {
   );
   assert_lottie!(json);
 }
+
+#[test]
+fn zero_chord_dashed_bezier_stays_bounded() {
+  // bbox.tgs: 46 vertices all on [256,256] with every tangent at 140000, so
+  // chord and bbox both measure zero while the real curve is ~294k px per
+  // segment — a 0.005 dash period slices that into ~1.3e9 pieces. The
+  // keyframe hides behind a precomp with `st:-1`, current on root frame 0.
+  let vertices = (0..46).map(|_| "[256,256]").collect::<Vec<_>>().join(",");
+  let tangents = (0..46).map(|_| "[140000,140000]").collect::<Vec<_>>().join(",");
+  let json = format!(
+    r#"{{"v":"5.7.4","fr":60,"ip":0,"op":2,"w":512,"h":512,"assets":[{{"id":"c1","layers":[{{"ddd":0,"ind":1,"ty":4,"nm":"shape_layer","ip":0,"op":2,"st":0,"ks":{{}},"shapes":[{{"ty":"gr","it":[
+      {{"ty":"sh","ks":{{"a":1,"k":[
+        {{"t":0,"s":[{{"c":false,"v":[[256,256],[258,256]],"i":[[0,0],[0,0]],"o":[[0,0],[0,0]]}}],"i":{{"x":[0.833],"y":[0.833]}},"o":{{"x":[0.167],"y":[0.167]}}}},
+        {{"t":1,"s":[{{"c":false,"v":[{vertices}],"i":[{tangents}],"o":[{tangents}]}}]}}
+      ]}}}},
+      {{"ty":"st","c":{{"a":0,"k":[0,0,0,1]}},"o":{{"a":0,"k":100}},"w":{{"a":0,"k":2}},"lc":1,"lj":1,"d":[
+        {{"n":"d","v":{{"a":0,"k":0.005}}}},{{"n":"g","v":{{"a":0,"k":0.005}}}},{{"n":"o","v":{{"a":0,"k":0}}}}
+      ]}},
+      {{"ty":"tr","p":{{"a":0,"k":[256,256]}},"a":{{"a":0,"k":[0,0]}},"s":{{"a":0,"k":[100,100]}},"r":{{"a":0,"k":0}},"o":{{"a":0,"k":100}}}}
+    ]}}]}}]}}],"layers":[{{"ddd":0,"ind":1,"ty":0,"nm":"wrap","refId":"c1","ip":0,"op":2,"st":-1,"w":512,"h":512}}]}}"#
+  );
+  assert_lottie!(json, 512, 0, 2);
+}

--- a/src/tests/dos.rs
+++ b/src/tests/dos.rs
@@ -2459,3 +2459,40 @@ fn zero_chord_dashed_bezier_stays_bounded() {
   );
   assert_lottie!(json, 512, 0, 2);
 }
+
+#[test]
+fn overshooting_easing_dashed_path_stays_bounded() {
+  // Both authored paths fit PR #8's dash estimate: 45 * 100 / 2.2 < 2048.
+  // At frame 1, x handles (0, 1) select u=0.5, but y handles (100, 100)
+  // yield progress 75.125. Tangents grow to 7512.5, so the intermediate
+  // curve exceeds the authored-keyframe estimate by over 75 times.
+  let vertices = (0..46).map(|_| "[32,32]").collect::<Vec<_>>().join(",");
+  let zero = (0..46).map(|_| "[0,0]").collect::<Vec<_>>().join(",");
+  let tangents = (0..46).map(|_| "[100,100]").collect::<Vec<_>>().join(",");
+  let json = format!(
+    r#"{{"v":"5.7.4","fr":60,"ip":0,"op":3,"w":64,"h":64,"layers":[{{"ty":4,"ind":1,"ip":0,"op":3,"ks":{{}},"shapes":[
+      {{"ty":"sh","ks":{{"a":1,"k":[
+        {{"t":0,"s":[{{"c":false,"v":[{vertices}],"i":[{zero}],"o":[{zero}]}}],"o":{{"x":0,"y":100}},"i":{{"x":1,"y":100}}}},
+        {{"t":2,"s":[{{"c":false,"v":[{vertices}],"i":[{tangents}],"o":[{tangents}]}}]}}
+      ]}}}},
+      {{"ty":"st","c":{{"k":[0,0,0,1]}},"o":{{"k":100}},"w":{{"k":2}},"lc":1,"lj":2,"d":[
+        {{"n":"d","v":{{"k":1.1}}}},{{"n":"g","v":{{"k":1.1}}}},{{"n":"o","v":{{"k":0}}}}
+      ]}}
+    ]}}]}}"#
+  );
+  assert_lottie!(json, 64, 1, 2);
+}
+
+#[test]
+fn single_vertex_closed_dashed_bezier_stays_bounded() {
+  // A closed path with one vertex still has a cubic from that vertex back
+  // to itself. PR #8's count < 2 shortcut reports zero length, although
+  // the tangents create a large out-and-back curve and millions of dashes.
+  let json = r#"{"v":"5.7.4","fr":60,"ip":0,"op":1,"w":64,"h":64,"layers":[{"ty":4,"ind":1,"ip":0,"op":1,"ks":{},"shapes":[
+    {"ty":"sh","ks":{"k":{"c":true,"v":[[32,32]],"i":[[140000,140000]],"o":[[140000,140000]]}}},
+    {"ty":"st","c":{"k":[0,0,0,1]},"o":{"k":100},"w":{"k":2},"lc":1,"lj":1,"d":[
+      {"n":"d","v":{"k":0.005}},{"n":"g","v":{"k":0.005}},{"n":"o","v":{"k":0}}
+    ]}
+  ]}]}"#;
+  assert_lottie!(json);
+}


### PR DESCRIPTION
soo the dash guards measure path length by chords between vertices, and only at
frame 0. every vertex is on the same point -> length 0 -> nothing trips. but the
tangents still pull the real curve ~294k px out and back, and 0.005 dashes slice
that into ~1.3e9 pieces in `VDasher`. 100% cpu + ram climbing until oom.

(also the bad keyframe is at `t:1` behind a precomp with `st:-1`, so
`eval(0.0)` never even looked at it)

<details><summary>bbox.tgs</summary>

```
lain@m68k ~/D/tgs> cat bbox.tgs | gzip -d | jq
{
  "v": "5.7.4",
  "fr": 60.0,
  "ip": 0,
  "op": 2,
  "w": 512,
  "h": 512,
  "nm": "tlottie bbox freeze > @thebadinteger",
  "x": {
    "author": "@badinteger"
  },
  "assets": [
    {
      "id": "c1",
      "layers": [
        {
          "ddd": 0,
          "ind": 1,
          "ty": 4,
          "nm": "shape_layer",
          "ip": 0,
          "op": 2,
          "st": 0,
          "ks": {},
          "shapes": [
            {
              "ty": "gr",
              "nm": "g",
              "it": [
                {
                  "ty": "sh",
                  "nm": "p",
                  "ks": {
                    "a": 1,
                    "k": [
                      {
                        "t": 0,
                        "s": [
                          {
                            "c": false,
                            "v": [
                              [
                                256.0,
                                256.0
                              ],
                              [
                                258.0,
                                256.0
                              ]
                            ],
                            "i": [
                              [
                                0.0,
                                0.0
                              ],
                              [
                                0.0,
                                0.0
                              ]
                            ],
                            "o": [
                              [
                                0.0,
                                0.0
                              ],
                              [
                                0.0,
                                0.0
                              ]
                            ]
                          }
                        ],
                        "i": {
                          "x": [
                            0.833
                          ],
                          "y": [
                            0.833
                          ]
                        },
                        "o": {
                          "x": [
                            0.167
                          ],
                          "y": [
                            0.167
                          ]
                        }
                      },
                      {
                        "t": 1,
                        "s": [
                          {
                            "c": false,
                            "v": [
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ],
                              [
                                256.0,
                                256.0
                              ]
                            ],
                            "i": [
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ]
                            ],
                            "o": [
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ],
                              [
                                140000.0,
                                140000.0
                              ]
                            ]
                          }
                        ]
                      }
                    ]
                  }
                },
                {
                  "ty": "st",
                  "nm": "s",
                  "c": {
                    "a": 0,
                    "k": [
                      0.0,
                      0.0,
                      0.0,
                      1.0
                    ]
                  },
                  "o": {
                    "a": 0,
                    "k": 100
                  },
                  "w": {
                    "a": 0,
                    "k": 2
                  },
                  "lc": 1,
                  "lj": 1,
                  "d": [
                    {
                      "n": "d",
                      "v": {
                        "a": 0,
                        "k": 0.005
                      }
                    },
                    {
                      "n": "g",
                      "v": {
                        "a": 0,
                        "k": 0.005
                      }
                    },
                    {
                      "n": "o",
                      "v": {
                        "a": 0,
                        "k": 0
                      }
                    }
                  ]
                },
                {
                  "ty": "tr",
                  "p": {
                    "a": 0,
                    "k": [
                      256.0,
                      256.0
                    ]
                  },
                  "a": {
                    "a": 0,
                    "k": [
                      0.0,
                      0.0
                    ]
                  },
                  "s": {
                    "a": 0,
                    "k": [
                      100.0,
                      100.0
                    ]
                  },
                  "r": {
                    "a": 0,
                    "k": 0.0
                  },
                  "o": {
                    "a": 0,
                    "k": 100
                  }
                }
              ]
            }
          ]
        }
      ]
    }
  ],
  "layers": [
    {
      "ddd": 0,
      "ind": 1,
      "ty": 0,
      "nm": "wrap",
      "refId": "c1",
      "ip": 0,
      "op": 2,
      "st": -1,
      "w": 512,
      "h": 512
    }
  ]
}
lain@m68k ~/D/tgs>
```

</details>

```
"v": [[256,256],[256,256], ...x46 ],   // all on one point
"i": [[140000,140000], ...  ], // wth??
"o": [[140000,140000], ... ],
"d": [{"n":"d","v":{"k":0.005}}, {"n":"g","v":{"k":0.005}}]
```

fix: measure the control polygon instead of the chord, and scan all keyframes.
zero tangents -> polygon == chord, so normal paths score exactly as before.

the polygon is a real bound (chord <= L <= polygon for any bezier), not an
estimate - this curve has a cusp at t=0.5, which is exactly where the cheap
arclength estimates stop being guaranteed.

credits for the original author: [here](https://t.me/thebadinteger/129)